### PR TITLE
Add POST /vault/store endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ This enables fast creation of business logic and automations — without writing
 
 PURAIFY is composed of specialized engines, each with a single responsibility:
 
-| Engine              | Purpose                                                    |
-|---------------------|------------------------------------------------------------|
-| Platform Builder    | Converts user prompts into structured blueprints           |
-| Vault Engine        | Stores API tokens and credentials securely                 |
-| Execution Engine    | Executes actions defined in the blueprint (e.g. Slack API) |
-| Gateway             | Routes requests and orchestrates calls between engines     |
+| Engine | Purpose | Status |
+|---|---|---|
+| Platform Builder | Converts user prompts into structured blueprints | 🔲 Not Started |
+| Vault Engine | Stores API tokens and credentials securely | 🟢 In Progress |
+| Execution Engine | Executes actions defined in the blueprint (e.g. Slack API) | 🔲 Not Started |
+| Gateway | Routes requests and orchestrates calls between engines | 🔲 Not Started |
 
 Each engine is an isolated microservice that communicates through internal APIs.
 

--- a/SYSTEM_STATE.md
+++ b/SYSTEM_STATE.md
@@ -10,7 +10,7 @@ As of now, the system includes engine structure and specifications — but no fu
 | Component           | Description                                  | Status       | Entry File (Planned)              |
 |---------------------|----------------------------------------------|--------------|-----------------------------------|
 | Platform Builder    | Converts user prompts into structured blueprints | 🔲 Not Started | `engines/platform-builder/src/index.ts` |
-| Vault Engine        | Stores and retrieves tokens per service/project | 🔲 Not Started | `engines/vault/src/index.ts`      |
+| Vault Engine        | Stores and retrieves tokens per service/project | 🟢 In Progress | `engines/vault/src/index.ts`      |
 | Execution Engine    | Executes actions defined in blueprint JSON     | 🔲 Not Started | `engines/execution/src/index.ts`  |
 | Gateway             | API entry point and engine orchestrator        | 🔲 Not Started | `gateway/src/index.ts`            |
 | Validation Engine   | Validates blueprints before execution          | 🟡 Planned     | `engines/validation/` (TBD)       |
@@ -35,7 +35,7 @@ As of now, the system includes engine structure and specifications — but no fu
 | Engine            | APIs            | Status       |
 |-------------------|------------------|--------------|
 | Platform Builder  | None             | 🔲 Planned    |
-| Vault Engine      | None             | 🔲 Planned    |
+| Vault Engine      | `POST /vault/store` | 🟢 Active    |
 | Execution Engine  | None             | 🔲 Planned    |
 | Gateway           | None             | 🔲 Planned    |
 
@@ -54,7 +54,8 @@ As of now, the system includes engine structure and specifications — but no fu
 
 ## 🚧 Immediate Next Steps
 
-- [ ] Start implementation of Vault Engine API (`POST /vault/store`, `GET /vault/get`)
+ - [x] Implemented `POST /vault/store` endpoint for Vault Engine
+ - [ ] Add `GET /vault/get` endpoint
 - [ ] Begin Gateway skeleton with routing between engines
 - [ ] Define actual blueprint structure for Platform Builder
 - [ ] Add internal dev/test setup (e.g., nodemon, tsconfig)
@@ -68,4 +69,4 @@ The next step is starting to implement each engine's basic code and run minimal 
 
 ---
 
-Last updated: July 25, 2025
+Last updated: July 26, 2025

--- a/engines/vault/README.md
+++ b/engines/vault/README.md
@@ -26,7 +26,31 @@ Example Flow:
 
 ---
 
-## ⚙️ Planned API Endpoints
+## ⚙️ API Endpoints
+
+### `POST /vault/store`
+
+Stores a token for a specific service and project.
+
+**Request Body**
+
+```json
+{
+  "projectId": "platform-a",
+  "service": "slack",
+  "token": "xoxb-abc123xyz"
+}
+```
+
+**Response**
+
+```json
+{
+  "success": true
+}
+```
+
+### `POST /vault/token` *(planned)*
 
 ```
 POST /vault/token

--- a/engines/vault/src/index.ts
+++ b/engines/vault/src/index.ts
@@ -1,0 +1,21 @@
+import express, { Request, Response } from 'express';
+
+const app = express();
+app.use(express.json());
+
+// simple in-memory store: { [projectId]: { [service]: token } }
+const tokenStore: Record<string, Record<string, string>> = {};
+
+app.post('/vault/store', (req: Request, res: Response) => {
+  const { projectId, service, token } = req.body || {};
+  if (!projectId || !service || !token) {
+    return res.status(400).json({ error: 'projectId, service and token are required' });
+  }
+  if (!tokenStore[projectId]) {
+    tokenStore[projectId] = {};
+  }
+  tokenStore[projectId][service] = token;
+  return res.json({ success: true });
+});
+
+export default app;


### PR DESCRIPTION
## Summary
- implement in-memory token store and POST /vault/store
- document Vault store endpoint
- update engine status tables and system state

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883c942cc70832eaa59b18fcd49a1af