### PR TITLE
Update engine docs with structure sections

### DIFF
--- a/CONTRIBUTION_PROTOCOL.md
+++ b/CONTRIBUTION_PROTOCOL.md
@@ -57,6 +57,18 @@ If you touch a specific engine:
 - Update its capabilities and responsibilities
 - Clarify integration points if modified
 
+#### 🔄 Per-Engine Structure Maintenance
+
+Whenever you:
+- Add, remove or reorganize files/folders inside an engine
+- Change entrypoints, core logic files, or structure
+
+You **must update** that engine’s `README.md` to reflect the new structure.
+
+Each engine’s README must include:
+- A `📁 Engine Structure` section with an updated tree view
+- Short explanation of key files
+
 ---
 
 ### 4. Optional: Add to `CHANGELOG.md` (future)

--- a/engines/execution/README.md
+++ b/engines/execution/README.md
@@ -1,5 +1,7 @@
 # Execution Engine
 
+> This engine is part of the PURAIFY system. For full system overview, see the main [README.md](../../README.md)
+
 ## 🧠 Overview
 
 The Execution Engine is a core component in the PURAIFY platform. Its primary responsibility is to **execute actionable steps** defined by other engines, primarily the Platform Builder and Gateway.
@@ -7,6 +9,22 @@ The Execution Engine is a core component in the PURAIFY platform. Its primary re
 While other engines handle tasks like blueprint generation, validation, and credential storage — the Execution Engine is the **actor**. It receives executable instructions, retrieves necessary tokens from the Vault Engine, and performs external or internal actions such as sending a message, triggering an API, or writing to a data store.
 
 It acts as the operational “hands” of PURAIFY, turning definitions into real-world effects.
+
+---
+
+## 📁 Engine Structure
+
+```text
+execution/
+├── package.json
+├── README.md
+└── src/
+    └── index.ts
+```
+
+- `src/index.ts` is the placeholder Express entry point for action execution.
+- `package.json` manages dependencies and scripts.
+- `README.md` (this file) outlines Execution's responsibilities.
 
 ---
 

--- a/engines/platform-builder/README.md
+++ b/engines/platform-builder/README.md
@@ -1,5 +1,7 @@
 # Platform Builder Engine
 
+> This engine is part of the PURAIFY system. For full system overview, see the main [README.md](../../README.md)
+
 ## 🧠 Overview
 
 The Platform Builder Engine is the **entry point** of PURAIFY’s creation process.  
@@ -8,6 +10,22 @@ Its role is to transform a user's high-level intent or description (e.g., "I wan
 This blueprint becomes the foundation for further validation, execution, and automation.
 
 It is essentially the "compiler" for business logic — converting ideas into a formalized instruction set (JSON) that the rest of the platform can act on.
+
+---
+
+## 📁 Engine Structure
+
+```text
+platform-builder/
+├── package.json
+├── README.md
+└── src/
+    └── index.ts
+```
+
+- `src/index.ts` is the planned Express entry point for blueprint generation.
+- `package.json` defines dependencies and scripts (currently empty).
+- `README.md` (this file) describes the engine's purpose and API.
 
 ---
 

--- a/engines/vault/README.md
+++ b/engines/vault/README.md
@@ -1,5 +1,7 @@
 # Vault Engine
 
+> This engine is part of the PURAIFY system. For full system overview, see the main [README.md](../../README.md)
+
 ## 🧠 Overview
 
 The Vault Engine is the **secure credential store** within the PURAIFY ecosystem. Its role is to manage and provide access to **API keys, tokens, secrets, and credentials** needed by other engines (e.g., Execution Engine) to interact with external systems such as Slack, Notion, Gmail, Google Sheets, and more.
@@ -7,6 +9,22 @@ The Vault Engine is the **secure credential store** within the PURAIFY ecosystem
 It functions as a centralized "secret manager", allowing engines to **query for credentials by service and project** in a secure and structured way.
 
 The Vault Engine does not execute actions or orchestrate flows — it exists to **hold and serve sensitive authentication data** safely and efficiently.
+
+---
+
+## 📁 Engine Structure
+
+```text
+vault/
+├── package.json
+├── README.md
+└── src/
+    └── index.ts
+```
+
+- `src/index.ts` is the main Express entry point handling Vault routes.
+- `package.json` lists dependencies and scripts (currently minimal).
+- `README.md` (this file) documents Vault usage and API.
 
 ---
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -1,5 +1,7 @@
 # Gateway
 
+> This engine is part of the PURAIFY system. For full system overview, see the main [README.md](../README.md)
+
 ## 🧠 Overview
 
 The Gateway is the **central coordinator** of the PURAIFY system.  
@@ -12,6 +14,22 @@ The Gateway itself does not contain any business logic — instead, it is respon
 - **Delegation to engines**
 
 It is essentially the brainstem that connects and controls the flow of data between PURAIFY’s modular components.
+
+---
+
+## 📁 Engine Structure
+
+```text
+gateway/
+├── package.json
+├── README.md
+└── src/
+    └── index.ts
+```
+
+- `src/index.ts` is the central Express router that delegates to all engines.
+- `package.json` defines Gateway dependencies and scripts.
+- `README.md` (this file) explains routing behavior and planned endpoints.
 
 ---
 


### PR DESCRIPTION
## Summary
- document per-engine structure maintenance protocol
- add engine structure sections to Vault, Platform Builder, Execution and Gateway docs
- remind readers each engine is part of the PURAIFY system

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883ce996570832eabf6203d29aead1c