### PR TITLE
Update contribution protocol with Codex note tracking

### DIFF
--- a/CONTRIBUTION_PROTOCOL.md
+++ b/CONTRIBUTION_PROTOCOL.md
@@ -168,6 +168,27 @@ Whenever Codex completes a task originally recorded as a note or todo:
 
 This ensures internal alignment and traceability of thought process.
 
+### 🔍 Codex Notes Location Tracking
+
+Whenever Codex creates an inline note inside any engine file (for example
+`src/index.ts`), it must also record that note in `SYSTEM_STATE.md` under a new
+section titled `## 🧠 Codex Notes Map`.
+
+This map lists all currently active Codex Notes and their locations. Example:
+
+```
+🧠 Codex Notes Map
+engines/vault/src/index.ts:
+  Note: Align /vault/get with documented /vault/token/:project/:service
+
+engines/execution/src/index.ts:
+  Note: Execution engine still lacks action runner registry
+```
+
+Notes tracked here must be updated or removed once resolved. If a file is
+restructured, migrate the note entry accordingly so future runs can revisit the
+correct context.
+
 ### 🔍 Responsibility
 
 Before starting any new task in a given engine:

--- a/SYSTEM_STATE.md
+++ b/SYSTEM_STATE.md
@@ -62,6 +62,12 @@ As of now, most engines only contain scaffold code. The Vault Engine exposes a w
 
 ---
 
+## 🧠 Codex Notes Map
+
+_No active Codex Notes at this time._
+
+---
+
 ## 🧭 Summary
 
 The PURAIFY project is in the **pre-development phase**, with full architecture, specs, and documentation in place.  


### PR DESCRIPTION
## Summary
- clarify note location tracking in `CONTRIBUTION_PROTOCOL.md`
- add `🧠 Codex Notes Map` section to `SYSTEM_STATE.md`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6883df254970832e9382ec63fdba7873