### PR TITLE
Align docs and add TypeScript configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,18 +41,26 @@ This is a monorepo organized by engine:
 puraify/
 ├── engines/
 │   ├── vault/
+│   │   ├── package.json
+│   │   ├── tsconfig.json
 │   │   ├── src/
 │   │   │   └── index.ts            ← Entry point for Vault Engine
 │   │   └── README.md               ← Vault Engine specification
 │   ├── platform-builder/
+│   │   ├── package.json
+│   │   ├── tsconfig.json
 │   │   ├── src/
 │   │   │   └── index.ts            ← Entry point for Platform Builder
 │   │   └── README.md               ← Platform Builder specification
 │   ├── execution/
+│   │   ├── package.json
+│   │   ├── tsconfig.json
 │   │   ├── src/
 │   │   │   └── index.ts            ← Entry point for Execution Engine
 │   │   └── README.md               ← Execution Engine specification
 ├── gateway/
+│   ├── package.json
+│   ├── tsconfig.json
 │   ├── src/
 │   │   └── index.ts                ← Main API router for the PURAIFY system
 │   └── README.md                   ← Gateway specification
@@ -75,13 +83,17 @@ Each engine is self-contained, and its README defines its APIs, responsibilities
 ---
 
 ## 🚀 Getting Started
+Requires Node.js v20+.
 
 To start working on the project:
 
 1. Pick an engine (e.g., `vault`)
-2. Read its `README.md` inside `engines/vault/`
-3. Run its dev server or use Docker Compose (coming soon)
-4. Use the Gateway to connect everything
+2. Navigate to its folder and run:
+   ```bash
+   npm install
+   npm run dev
+   ```
+3. Use the Gateway to connect everything (Docker Compose coming soon)
 
 ---
 

--- a/SYSTEM_STATE.md
+++ b/SYSTEM_STATE.md
@@ -1,8 +1,7 @@
 # PURAIFY — Live System State
 
 This file documents the current **real-time** state of the PURAIFY platform.  
-As of now, most engines only contain scaffold code. The Vault Engine exposes a working `POST /vault/store` endpoint while the rest remain placeholders.
-
+As of now, most engines only contain scaffold code. The Vault Engine exposes a working `POST /vault/store` endpoint and plans to add `GET /vault/token/:project/:service`.
 ---
 
 ## 🧱 System Build Status
@@ -35,7 +34,7 @@ As of now, most engines only contain scaffold code. The Vault Engine exposes a w
 | Engine            | APIs            | Status       |
 |-------------------|------------------|--------------|
 | Platform Builder  | None             | 🔲 Planned    |
-| Vault Engine      | `POST /vault/store` | 🟢 Active    |
+| Vault Engine      | `POST /vault/store`, `GET /vault/token/:project/:service` | 🟡 Planned |
 | Execution Engine  | None             | 🔲 Planned    |
 | Gateway           | None             | 🔲 Planned    |
 
@@ -55,7 +54,7 @@ As of now, most engines only contain scaffold code. The Vault Engine exposes a w
 ## 🚧 Immediate Next Steps
 
  - [x] Implemented `POST /vault/store` endpoint for Vault Engine
- - [ ] Add `GET /vault/get` endpoint
+- [ ] Add `GET /vault/token/:project/:service` endpoint
 - [ ] Begin Gateway skeleton with routing between engines
 - [ ] Define actual blueprint structure for Platform Builder
 - [ ] Add internal dev/test setup (e.g., nodemon, tsconfig)
@@ -63,8 +62,8 @@ As of now, most engines only contain scaffold code. The Vault Engine exposes a w
 ---
 
 ## 🧠 Codex Notes Map
-
-_No active Codex Notes at this time._
+engines/vault/src/index.ts:
+  Note: GET /vault/token/:project/:service endpoint not yet implemented
 
 ---
 

--- a/engines/execution/README.md
+++ b/engines/execution/README.md
@@ -17,13 +17,23 @@ It acts as the operational “hands” of PURAIFY, turning definitions into real
 ```text
 execution/
 ├── package.json
+├── tsconfig.json
 ├── README.md
 └── src/
     └── index.ts
 ```
+## 🚀 Development Setup
+
+Requires Node.js v20+.
+
+```bash
+npm install
+npm run dev
+```
 
 - `src/index.ts` is the placeholder Express entry point for action execution.
 - `package.json` manages dependencies and scripts.
+- `tsconfig.json` contains TypeScript compiler settings.
 - `README.md` (this file) outlines Execution's responsibilities.
 
 ---

--- a/engines/execution/package.json
+++ b/engines/execution/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@puraify/execution",
+  "version": "0.1.0",
+  "description": "PURAIFY Execution Engine",
+  "dependencies": {
+    "express": "^4.18.2",
+    "typescript": "^5.4.2",
+    "ts-node": "^10.9.1",
+    "body-parser": "^1.20.2"
+  },
+  "scripts": {
+    "dev": "ts-node src/index.ts",
+    "start": "node dist/index.js",
+    "build": "tsc"
+  }
+}

--- a/engines/execution/tsconfig.json
+++ b/engines/execution/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  }
+}

--- a/engines/platform-builder/README.md
+++ b/engines/platform-builder/README.md
@@ -18,13 +18,23 @@ It is essentially the "compiler" for business logic — converting ideas into a 
 ```text
 platform-builder/
 ├── package.json
+├── tsconfig.json
 ├── README.md
 └── src/
     └── index.ts
 ```
+## 🚀 Development Setup
+
+Requires Node.js v20+.
+
+```bash
+npm install
+npm run dev
+```
 
 - `src/index.ts` is the planned Express entry point for blueprint generation.
-- `package.json` defines dependencies and scripts (currently empty).
+- `package.json` defines dependencies and scripts.
+- `tsconfig.json` contains TypeScript compiler settings.
 - `README.md` (this file) describes the engine's purpose and API.
 
 ---

--- a/engines/platform-builder/package.json
+++ b/engines/platform-builder/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@puraify/platform-builder",
+  "version": "0.1.0",
+  "description": "PURAIFY Platform Builder Engine",
+  "dependencies": {
+    "express": "^4.18.2",
+    "typescript": "^5.4.2",
+    "ts-node": "^10.9.1",
+    "body-parser": "^1.20.2"
+  },
+  "scripts": {
+    "dev": "ts-node src/index.ts",
+    "start": "node dist/index.js",
+    "build": "tsc"
+  }
+}

--- a/engines/platform-builder/tsconfig.json
+++ b/engines/platform-builder/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  }
+}

--- a/engines/vault/README.md
+++ b/engines/vault/README.md
@@ -13,14 +13,23 @@ The Vault Engine does not execute actions or orchestrate flows — it exists to 
 ---
 
 ## 📁 Engine Structure
-
 ```text
 vault/
 ├── package.json
+├── tsconfig.json
 ├── README.md
 └── src/
     └── index.ts
 ```
+## 🚀 Development Setup
+
+Requires Node.js v20+.
+
+```bash
+npm install
+npm run dev
+```
+
 
 - `src/index.ts` is the main Express entry point handling Vault routes.
 - `package.json` lists dependencies and scripts (currently minimal).

--- a/engines/vault/codex-todo.md
+++ b/engines/vault/codex-todo.md
@@ -1,0 +1,2 @@
+## TODO
+- [ ] Implement GET /vault/token/:project/:service endpoint

--- a/engines/vault/package.json
+++ b/engines/vault/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@puraify/vault",
+  "version": "0.1.0",
+  "description": "PURAIFY Vault Engine",
+  "dependencies": {
+    "express": "^4.18.2",
+    "typescript": "^5.4.2",
+    "ts-node": "^10.9.1",
+    "body-parser": "^1.20.2"
+  },
+  "scripts": {
+    "dev": "ts-node src/index.ts",
+    "start": "node dist/index.js",
+    "build": "tsc"
+  }
+}

--- a/engines/vault/src/index.ts
+++ b/engines/vault/src/index.ts
@@ -1,4 +1,8 @@
-import express, { Request, Response } from 'express';
+/**
+ * 🧠 Codex Note:
+ * - GET /vault/token/:project/:service endpoint not yet implemented
+ */
+import express, { Request, Response } from "express";
 
 const app = express();
 app.use(express.json());
@@ -19,3 +23,4 @@ app.post('/vault/store', (req: Request, res: Response) => {
 });
 
 export default app;
+

--- a/engines/vault/tsconfig.json
+++ b/engines/vault/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  }
+}

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -22,13 +22,24 @@ It is essentially the brainstem that connects and controls the flow of data betw
 ```text
 gateway/
 ├── package.json
+├── tsconfig.json
 ├── README.md
 └── src/
     └── index.ts
 ```
+## 🚀 Development Setup
+
+Requires Node.js v20+.
+
+```bash
+npm install
+npm run dev
+```
 
 - `src/index.ts` is the central Express router that delegates to all engines.
 - `package.json` defines Gateway dependencies and scripts.
+- `tsconfig.json` contains TypeScript compiler settings.
+- `README.md` (this file) explains routing behavior and planned endpoints.
 - `README.md` (this file) explains routing behavior and planned endpoints.
 
 ---

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@puraify/gateway",
+  "version": "0.1.0",
+  "description": "PURAIFY Gateway",
+  "dependencies": {
+    "express": "^4.18.2",
+    "typescript": "^5.4.2",
+    "ts-node": "^10.9.1",
+    "body-parser": "^1.20.2"
+  },
+  "scripts": {
+    "dev": "ts-node src/index.ts",
+    "start": "node dist/index.js",
+    "build": "tsc"
+  }
+}

--- a/gateway/tsconfig.json
+++ b/gateway/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- add package.json and tsconfig to each engine and gateway
- document new Node dev workflow
- resolve Vault GET route name in docs and SYSTEM_STATE
- note missing GET route in vault index
- update project structure in main README

## Testing
- `npm run build` (fails: Cannot find module 'express')

------
https://chatgpt.com/codex/tasks/task_e_6883e16622d8832e90f8cca923ce804a