### PR TITLE
Dry run notes and todos for engines

### DIFF
--- a/SYSTEM_STATE.md
+++ b/SYSTEM_STATE.md
@@ -64,6 +64,16 @@ As of now, most engines only contain scaffold code. The Vault Engine exposes a w
 ## 🧠 Codex Notes Map
 engines/vault/src/index.ts:
   Note: GET /vault/token/:project/:service endpoint not yet implemented
+  Note: Dev server fails to run without npm packages; offline install steps needed
+engines/platform-builder/src/index.ts:
+  Note: Express server placeholder; builder logic not implemented
+  Note: Dev environment fails without packages (ts-node) in offline mode
+engines/execution/src/index.ts:
+  Note: Execution logic missing; placeholder only
+  Note: Dev environment fails without packages (ts-node) in offline mode
+gateway/src/index.ts:
+  Note: Gateway routing not implemented
+  Note: Dev environment fails without packages (ts-node) in offline mode
 
 ---
 
@@ -74,4 +84,4 @@ The next step is starting to implement each engine's basic code and run minimal 
 
 ---
 
-Last updated: July 26, 2025
+Last updated: July 25, 2025

--- a/engines/execution/codex-todo.md
+++ b/engines/execution/codex-todo.md
@@ -1,0 +1,3 @@
+## TODO
+- [ ] Implement basic action runner and /execute endpoint
+- [ ] Provide lockfile/offline npm install instructions

--- a/engines/execution/src/index.ts
+++ b/engines/execution/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * 🧠 Codex Note:
+ * - Execution logic not implemented yet; placeholder file.
+ * - npm dependencies missing; ts-node absent in offline environment.
+ */
+
+// TODO: build action runner and integrate with Vault
+

--- a/engines/platform-builder/codex-todo.md
+++ b/engines/platform-builder/codex-todo.md
@@ -1,0 +1,3 @@
+## TODO
+- [ ] Create basic Express server with /builder/create endpoint
+- [ ] Provide lockfile/offline instructions so npm install works

--- a/engines/platform-builder/src/index.ts
+++ b/engines/platform-builder/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * 🧠 Codex Note:
+ * - Express server placeholder; builder logic to be implemented.
+ * - Dev environment fails without npm packages (ts-node) due to offline setup.
+ */
+
+// TODO: implement basic Express app for Platform Builder
+

--- a/engines/vault/codex-todo.md
+++ b/engines/vault/codex-todo.md
@@ -1,2 +1,3 @@
 ## TODO
 - [ ] Implement GET /vault/token/:project/:service endpoint
+- [ ] Provide lockfile or offline instructions so npm install works

--- a/engines/vault/src/index.ts
+++ b/engines/vault/src/index.ts
@@ -1,6 +1,9 @@
 /**
  * 🧠 Codex Note:
  * - GET /vault/token/:project/:service endpoint not yet implemented
+ * - Dev environment cannot run without npm packages (ts-node, express)
+ *   because npm install fails in offline mode. Consider providing a lockfile
+ *   or pre-install instructions for codex.
  */
 import express, { Request, Response } from "express";
 

--- a/gateway/codex-todo.md
+++ b/gateway/codex-todo.md
@@ -1,0 +1,3 @@
+## TODO
+- [ ] Implement Gateway Express server with basic routing
+- [ ] Provide lockfile/offline instructions so npm install works

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * 🧠 Codex Note:
+ * - Gateway routing not implemented; file placeholder.
+ * - Dev environment fails without packages; ts-node not installed offline.
+ */
+
+// TODO: implement Express server to delegate to engines
+


### PR DESCRIPTION
## Summary
- document inability to run `npm install` offline
- leave Codex notes in every engine entry point
- add codex-todo lists for future setup
- track Codex notes in SYSTEM_STATE

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run dev` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883e5cf7474832ea964cf463ffd6bc5