### PR TITLE
Add ENGINE_SPEC placeholders and update protocol

### DIFF
--- a/CONTRIBUTION_PROTOCOL.md
+++ b/CONTRIBUTION_PROTOCOL.md
@@ -220,6 +220,19 @@ This ensures unresolved items are visible, tagged, and tracked across sessions.
 
 ---
 
+## 📘 Engine Specification Awareness
+
+Each engine folder may include an `ENGINE_SPEC.md` file describing its responsibilities, endpoints, integrations, and behavior.
+
+If Codex runs out of todos or Codex Notes, it should:
+
+1. Check whether `ENGINE_SPEC.md` exists
+2. Review it for hints, expectations, or discrepancies
+3. Log potential tasks or missing capabilities based on it
+4. If `ENGINE_SPEC.md` is missing or incomplete, Codex may log a todo or a note requesting clarification or manual input.
+
+---
+
 ## ✅ Example: Adding a new action to Execution Engine
 
 If you add a new action called `send_email` to Execution:

--- a/README.md
+++ b/README.md
@@ -45,25 +45,29 @@ puraify/
 │   │   ├── tsconfig.json
 │   │   ├── src/
 │   │   │   └── index.ts            ← Entry point for Vault Engine
-│   │   └── README.md               ← Vault Engine specification
+│   │   ├── README.md               ← Vault Engine specification
+│   │   └── ENGINE_SPEC.md          ← Manual spec placeholder
 │   ├── platform-builder/
 │   │   ├── package.json
 │   │   ├── tsconfig.json
 │   │   ├── src/
 │   │   │   └── index.ts            ← Entry point for Platform Builder
-│   │   └── README.md               ← Platform Builder specification
+│   │   ├── README.md               ← Platform Builder specification
+│   │   └── ENGINE_SPEC.md          ← Manual spec placeholder
 │   ├── execution/
 │   │   ├── package.json
 │   │   ├── tsconfig.json
 │   │   ├── src/
 │   │   │   └── index.ts            ← Entry point for Execution Engine
-│   │   └── README.md               ← Execution Engine specification
+│   │   ├── README.md               ← Execution Engine specification
+│   │   └── ENGINE_SPEC.md          ← Manual spec placeholder
 ├── gateway/
 │   ├── package.json
 │   ├── tsconfig.json
 │   ├── src/
 │   │   └── index.ts                ← Main API router for the PURAIFY system
-│   └── README.md                   ← Gateway specification
+│   ├── README.md                   ← Gateway specification
+│   └── ENGINE_SPEC.md              ← Manual spec placeholder
 ├── docker-compose.yml              ← (Planned) Multi-service setup
 ├── README.md                       ← You are here — main project overview
 ```

--- a/SYSTEM_STATE.md
+++ b/SYSTEM_STATE.md
@@ -22,6 +22,7 @@ As of now, most engines only contain scaffold code. The Vault Engine exposes a w
 ✅ As of now, all engines have:
 - Their folder structures initialized
 - A dedicated `README.md` file with functional specification
+- A placeholder `ENGINE_SPEC.md` for manual specs
 - Listed entry point placeholders (`index.ts`)
 - System-level README and Contribution Protocols written
 

--- a/engines/execution/ENGINE_SPEC.md
+++ b/engines/execution/ENGINE_SPEC.md
@@ -1,0 +1,1 @@
+<!-- Specification will be written manually -->

--- a/engines/execution/README.md
+++ b/engines/execution/README.md
@@ -19,6 +19,7 @@ execution/
 ├── package.json
 ├── tsconfig.json
 ├── README.md
+├── ENGINE_SPEC.md
 └── src/
     └── index.ts
 ```
@@ -37,6 +38,7 @@ npm run dev
 - `package.json` manages dependencies and scripts.
 - `tsconfig.json` contains TypeScript compiler settings.
 - `README.md` (this file) outlines Execution's responsibilities.
+- `ENGINE_SPEC.md` will hold the detailed manual spec for this engine.
 
 ---
 

--- a/engines/platform-builder/ENGINE_SPEC.md
+++ b/engines/platform-builder/ENGINE_SPEC.md
@@ -1,0 +1,1 @@
+<!-- Specification will be written manually -->

--- a/engines/platform-builder/README.md
+++ b/engines/platform-builder/README.md
@@ -20,6 +20,7 @@ platform-builder/
 ├── package.json
 ├── tsconfig.json
 ├── README.md
+├── ENGINE_SPEC.md
 └── src/
     └── index.ts
 ```
@@ -38,6 +39,7 @@ npm run dev
 - `package.json` defines dependencies and scripts.
 - `tsconfig.json` contains TypeScript compiler settings.
 - `README.md` (this file) describes the engine's purpose and API.
+- `ENGINE_SPEC.md` is reserved for a detailed manual specification.
 
 ---
 

--- a/engines/vault/ENGINE_SPEC.md
+++ b/engines/vault/ENGINE_SPEC.md
@@ -1,0 +1,1 @@
+<!-- Specification will be written manually -->

--- a/engines/vault/README.md
+++ b/engines/vault/README.md
@@ -18,6 +18,7 @@ vault/
 ├── package.json
 ├── tsconfig.json
 ├── README.md
+├── ENGINE_SPEC.md
 └── src/
     └── index.ts
 ## 🚀 Development Setup
@@ -35,6 +36,7 @@ npm run dev
 - `src/index.ts` is the main Express entry point handling Vault routes.
 - `package.json` lists dependencies and scripts (currently minimal).
 - `README.md` (this file) documents Vault usage and API.
+- `ENGINE_SPEC.md` is reserved for a detailed manual specification.
 
 ---
 

--- a/gateway/ENGINE_SPEC.md
+++ b/gateway/ENGINE_SPEC.md
@@ -1,0 +1,1 @@
+<!-- Specification will be written manually -->

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -24,6 +24,7 @@ gateway/
 ├── package.json
 ├── tsconfig.json
 ├── README.md
+├── ENGINE_SPEC.md
 └── src/
     └── index.ts
 ```
@@ -42,6 +43,7 @@ npm run dev
 - `package.json` defines Gateway dependencies and scripts.
 - `tsconfig.json` contains TypeScript compiler settings.
 - `README.md` (this file) explains routing behavior and planned endpoints.
+- `ENGINE_SPEC.md` will contain a detailed manual specification.
 - `README.md` (this file) explains routing behavior and planned endpoints.
 
 ---


### PR DESCRIPTION
## Summary
- add placeholder `ENGINE_SPEC.md` to each engine
- document spec files in README project structure and engine READMEs
- describe ENGINE_SPEC usage in CONTRIBUTION_PROTOCOL
- note placeholder spec files in SYSTEM_STATE

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6883f6e026b0832ea277aa79a1b975c6