### PR TITLE
Add infra docs and global task tracking

### DIFF
--- a/CONTRIBUTION_PROTOCOL.md
+++ b/CONTRIBUTION_PROTOCOL.md
@@ -250,6 +250,26 @@ If Codex runs out of todos or Codex Notes, it should:
 
 ---
 
+### 📁 New File: ENGINE_DEPENDENCIES.md
+
+This file lives at the root of the repo and defines dependencies between engines.
+
+Each engine should be listed with the other engines it depends on, including relevant route examples.  Codex must keep this file updated when new engine interactions occur or routes are added/removed.
+
+Format example:
+```md
+### vault
+- depends on: platform-builder (/platform/blueprint/:id)
+- depends on: execution (/exec/token/verify)
+```
+
+### 🧠 New File: codex-todo.md (root-level)
+This root-level file contains system-level tasks — across engines, protocol-wide changes, or multi-engine coordination.  Codex uses this to track global efforts, like standardizing formats, adding shared infra files, or resolving architectural questions.
+
+Engine-specific tasks should not go here — they belong inside the engine folders.
+
+---
+
 ## 🧪 Testing Strategy
 
 Each engine must place tests under `tests/<engine>/` and expose an `npm run test` script in its `package.json`.

--- a/ENGINE_DEPENDENCIES.md
+++ b/ENGINE_DEPENDENCIES.md
@@ -1,0 +1,3 @@
+### vault
+- depends on: platform-builder (/platform/blueprint/:id)
+- depends on: execution (/exec/token/verify)

--- a/NAMESPACE_MAP.md
+++ b/NAMESPACE_MAP.md
@@ -1,0 +1,17 @@
+# Namespace Map
+
+## File/Module Names
+
+| Engine | File/Module | Notes |
+|--------|-------------|-------|
+| vault | example.ts | placeholder |
+| platform-builder | example.ts | placeholder |
+| execution | example.ts | placeholder |
+
+## Routes
+
+| Engine | Route | Notes |
+|--------|-------|-------|
+| vault | /vault/store | placeholder |
+| platform-builder | /builder/create | placeholder |
+| execution | /execute | placeholder |

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ puraify/
 │   ├── README.md                   ← Gateway specification
 │   └── ENGINE_SPEC.md              ← Manual spec placeholder
 ├── docker-compose.yml              ← (Planned) Multi-service setup
+├── ENGINE_DEPENDENCIES.md          ← Declared engine relationships
+├── NAMESPACE_MAP.md                ← Cross-engine name map
+├── codex-todo.md                   ← Global tasks
 ├── README.md                       ← You are here — main project overview
 ```
 

--- a/SYSTEM_STATE.md
+++ b/SYSTEM_STATE.md
@@ -78,6 +78,8 @@ gateway/src/index.ts:
   Note: ✅ Gateway routing implemented; blueprint orchestration pending
 integration-design:
   Note: ❓ Should Gateway or Execution Engine fetch Vault tokens during action execution?
+root-level:
+  Note: ENGINE_DEPENDENCIES.md, NAMESPACE_MAP.md and codex-todo.md added for cross-engine tracking. Engine-level codex-todo format expected.
 
 ---
 
@@ -88,4 +90,4 @@ The next step is to expand features, add validation, and integrate across engine
 
 ---
 
-Last updated: July 25, 2025
+Last updated: July 28, 2025

--- a/codex-todo.md
+++ b/codex-todo.md
@@ -1,0 +1,4 @@
+## TODO
+- [x] Create ENGINE_DEPENDENCIES.md
+- [x] Create NAMESPACE_MAP.md
+- [ ] Define standard codex-todo format across engines


### PR DESCRIPTION
## Summary
- add ENGINE_DEPENDENCIES.md for future cross-engine dependency listing
- add NAMESPACE_MAP.md to track file and route names
- add root codex-todo.md for global tasks
- document new infra files in README project structure
- log infra files in SYSTEM_STATE notes
- document new files in CONTRIBUTION_PROTOCOL

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68878d708a5c832e9cec9d1e94bf47ed