### PR TITLE
Add governance rule templates and question log

### DIFF
--- a/CONTRIBUTION_PROTOCOL.md
+++ b/CONTRIBUTION_PROTOCOL.md
@@ -289,6 +289,20 @@ Engine-specific tasks should not go here — they belong inside the engine folde
 
 ---
 
+## 📃 System Contracts
+
+Codex must consult `SYSTEM_RULES.md` before executing logic that depends on cross-engine behavior, error fallback strategies, user permissions, or handling missing components.
+
+### 🧠 Codex Question Log
+
+Architecture doubts or unresolved system questions may be recorded in `codex-questions.md`.
+
+- Each entry should be labeled as `[Qx]`.
+- Human contributors respond using `[Ax]` in the **Answers** section.
+- Codex should review this file regularly and avoid repeating unresolved mistakes.
+
+---
+
 ## 🧪 Testing Strategy
 
 Each engine must place tests under `tests/<engine>/` and expose an `npm run test` script in its `package.json`.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ puraify/
 ├── docker-compose.yml              ← (Planned) Multi-service setup
 ├── ENGINE_DEPENDENCIES.md          ← Declared engine relationships
 ├── NAMESPACE_MAP.md                ← Cross-engine name map
+├── SYSTEM_RULES.md                 ← High-level system policies
+├── codex-questions.md              ← Architecture question log
 ├── codex-todo.md                   ← Global tasks
 ├── README.md                       ← You are here — main project overview
 ```

--- a/SYSTEM_RULES.md
+++ b/SYSTEM_RULES.md
@@ -1,0 +1,34 @@
+# ⚖️ PURAIFY System Rules
+
+This file defines high-level system behavior policies.  
+Codex must consult this file before attempting complex orchestration logic or assumptions.
+
+---
+
+## ✅ General Principles
+
+_(To be completed manually)_
+
+---
+
+## 🔄 Flow Execution Rules
+
+_(To be completed manually)_
+
+---
+
+## 🔁 Retry & Failure Logic
+
+_(To be completed manually)_
+
+---
+
+## 🔐 User Consent Policies
+
+_(To be completed manually)_
+
+---
+
+## 🧩 Blueprint Assumptions
+
+_(To be completed manually)_

--- a/codex-questions.md
+++ b/codex-questions.md
@@ -1,0 +1,25 @@
+# ❓ Codex Questions & Architecture Doubts
+
+This file tracks open questions, unclear assumptions, or logic gaps Codex encounters during system understanding.
+
+---
+
+## 🧠 Questions from Codex
+
+### [Q1] Title or summary  
+**Context:**  
+File: `engines/execution/src/task-runner.ts`  
+Issue: `SYSTEM_RULES.md` does not define what to do if no Validation Engine exists.  
+Suggested Options:  
+- Should I block execution?  
+- Should I log a fallback note?  
+
+_Status: 🟡 Pending human response_
+
+---
+
+## ✅ Human Answers
+
+### [A1]  
+If no Validation Engine exists, block the flow and log a Codex Note requesting clarification.  
+_Status: ✅ Resolved_


### PR DESCRIPTION
## Summary
- add SYSTEM_RULES.md placeholder for system-level policies
- add codex-questions.md file for logging architecture questions
- reference new files in README project structure
- document system contracts and question log procedure in CONTRIBUTION_PROTOCOL

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68879a8c5404832e8c03914549160dd6