### PR TITLE
Add Proposed Actions workflow documentation

### DIFF
--- a/CONTRIBUTION_PROTOCOL.md
+++ b/CONTRIBUTION_PROTOCOL.md
@@ -341,9 +341,23 @@ If you add a new action called `send_email` to Execution:
 | Changed how Gateway routes | Gateway README.md, README.md               |
 | Added feature across multiple engines | All relevant engine docs + root files |
 
-Keep PURAIFY structured.  
-Make it understandable by humans and machines.  
+Keep PURAIFY structured.
+Make it understandable by humans and machines.
 Build like the system builds itself.
+
+---
+
+## 📌 Proposed Actions Workflow
+
+Environment or configuration updates require a transparent approval process:
+
+1. Add a bullet under `## Proposed Actions` in `codex-todo.md` describing the change, rationale, and expected impact.
+2. Add the same entry to `PROPOSED_ACTIONS_LOG.md` with status **Proposed**.
+3. Wait for an explicit human response of `YES` before applying the change.
+4. After approval, implement the change, update relevant docs, and update the log entry to **Executed** with date and approver.
+5. Keep both the todo item and log for historical reference.
+
+This ensures all environment changes are reviewed and fully traceable.
 
 Thanks,  
 PURAIFY System Protocol

--- a/PROPOSED_ACTIONS_LOG.md
+++ b/PROPOSED_ACTIONS_LOG.md
@@ -1,0 +1,7 @@
+# Proposed Actions Log
+
+This file records environment and configuration changes proposed by Codex. Each entry tracks its status from proposal to execution.
+
+| ID | Date | Description | Status | Approver | Notes |
+|----|------|-------------|--------|----------|-------|
+

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ You can contribute by:
 Please see [CONTRIBUTION_PROTOCOL.md](CONTRIBUTION_PROTOCOL.md) for required
 documentation rules. The latest implementation snapshot is kept in
 [SYSTEM_STATE.md](SYSTEM_STATE.md).
+Environment or configuration updates follow the "Proposed Actions" workflow defined in
+`CONTRIBUTION_PROTOCOL.md` and logged in `PROPOSED_ACTIONS_LOG.md`.
 
 ---
 

--- a/SYSTEM_RULES.md
+++ b/SYSTEM_RULES.md
@@ -106,9 +106,10 @@ Codex **must** consult this file before performing complex orchestration, error 
 ## 📌 Environment Change Approval Workflow
 
 - Codex must track every proposed modification to environment setup, configuration, dependencies, or protocols.
-- Log each proposal in `codex-todo.md` under a new heading `## Proposed Actions` with its description, rationale, and expected impact.
+- Log each proposal in `codex-todo.md` under the `## Proposed Actions` section with a clear description, rationale, and expected impact.
+- Record each proposal in `PROPOSED_ACTIONS_LOG.md` for permanent tracking.
 - Do not implement the change until a human explicitly approves with "YES".
-- Upon approval, update the environment, document the action with date and approver, and mark the item complete.
+- Upon approval, update the environment, document the action with date and approver in both files, and mark the item complete.
 - If rejected or unanswered, keep the proposal pending and note the outcome.
 - All environment changes must remain version-controlled for auditability.
 ---

--- a/codex-todo.md
+++ b/codex-todo.md
@@ -9,5 +9,13 @@
 - [ ] Add test folders and `npm test` scripts for each engine per CONTRIBUTION_PROTOCOL.md
 
 
+
 ## Proposed Actions
-Pending environment or configuration updates awaiting approval.
+**Log proposed environment updates here.** Each entry should include:
+- Description and rationale
+- Expected impact
+- Status: Proposed / Approved / Executed
+- Date and approver when resolved
+
+Refer to `PROPOSED_ACTIONS_LOG.md` for the historical record.
+


### PR DESCRIPTION
## Summary
- document environment change approval workflow in SYSTEM_RULES
- outline new procedure in CONTRIBUTION_PROTOCOL and README
- add Proposed Actions logging template
- expand root codex-todo with workflow instructions

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6887b6353f30832ea8e70eb2fc7a8551