### PR TITLE
Add docker compose and update todos

### DIFF
--- a/PROPOSED_ACTIONS_LOG.md
+++ b/PROPOSED_ACTIONS_LOG.md
@@ -5,5 +5,5 @@ This file records environment and configuration changes proposed by Codex. Each 
 | ID  | Date       | Description                            | Status   | Approver | Notes                   |
 |-----|------------|------------------------------------|----------|----------|-------------------------|
 | PA1 | 2025-07-28 | Create codex-todo format guide across engines | Approved | CEO      | Approved on 2025-07-28  |
-| PA2 | 2025-07-28 | Add docker-compose services for engines        | Approved | CEO      | Approved on 2025-07-28  |
-| PA3 | 2025-07-28 | Introduce Node test runner setup via ts-node   | Approved | CEO      | Approved on 2025-07-28  |
+| PA2 | 2025-07-28 | Add docker-compose services for engines        | Executed | CEO      | Executed on 2025-07-28  |
+| PA3 | 2025-07-28 | Introduce Node test runner setup via ts-node   | Executed | CEO      | Executed on 2025-07-28  |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ puraify/
 │   │   └── index.ts                ← Main API router for the PURAIFY system
 │   ├── README.md                   ← Gateway specification
 │   └── ENGINE_SPEC.md              ← Manual spec placeholder
-├── docker-compose.yml              ← (Planned) Multi-service setup
+├── docker-compose.yml              ← Docker Compose configuration
 ├── ENGINE_DEPENDENCIES.md          ← Declared engine relationships
 ├── NAMESPACE_MAP.md                ← Cross-engine name map
 ├── SYSTEM_RULES.md                 ← High-level system policies
@@ -109,7 +109,7 @@ To start working on the project:
    npm install
    npm run dev
    ```
-3. Use the Gateway to connect everything (Docker Compose coming soon)
+3. Use the Gateway to connect everything (`docker-compose up` to run all engines)
 
 ---
 

--- a/SYSTEM_STATE.md
+++ b/SYSTEM_STATE.md
@@ -59,6 +59,8 @@ As of now, most engines only contain scaffold code. The Vault Engine exposes a w
 - [x] Begin Gateway skeleton with routing between engines
 - [x] Define actual blueprint structure for Platform Builder (initial interface implemented)
 - [x] Add internal dev/test setup (e.g., nodemon, tsconfig)
+- [x] Added `docker-compose.yml` to run all engines together
+- [x] Node built-in test runner configured across engines
 
 ---
 ## 🔄 Next Integration Steps

--- a/codex-todo.md
+++ b/codex-todo.md
@@ -2,12 +2,11 @@
 - [x] Create ENGINE_DEPENDENCIES.md
 - [x] Create NAMESPACE_MAP.md
 - [ ] Define standard codex-todo format across engines
-- [ ] Define standard codex-todo format across engines
 - [x] Populate ENGINES_INDEX.md with current engines and statuses
 - [x] Expand ENGINE_DEPENDENCIES.md for Platform Builder, Execution, and Gateway
 - [x] Flesh out NAMESPACE_MAP.md with real modules and routes
-- [ ] Provide initial docker-compose.yml or document missing services
-- [ ] Add test folders and `npm test` scripts for each engine per CONTRIBUTION_PROTOCOL.md
+- [x] Provide initial docker-compose.yml or document missing services
+- [x] Add test folders and `npm test` scripts for each engine per CONTRIBUTION_PROTOCOL.md
 
 
 
@@ -21,6 +20,6 @@
 Refer to `PROPOSED_ACTIONS_LOG.md` for the historical record.
 
 - [PA1] Establish a standard format guide for `codex-todo.md` files across engines. Rationale: ensure consistency for automated parsing. Impact: documentation only. **Status: Proposed**
-- [PA2] Populate `docker-compose.yml` with services for each engine to simplify local development. Impact: easier startup. **Status: Proposed**
-- [PA3] Add minimal test infrastructure using Node's built-in test runner with `ts-node` loader. Impact: enable basic CI testing. **Status: Proposed**
+- [PA2] Populate `docker-compose.yml` with services for each engine to simplify local development. Impact: easier startup. **Status: Executed**
+- [PA3] Add minimal test infrastructure using Node's built-in test runner with `ts-node` loader. Impact: enable basic CI testing. **Status: Executed**
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: "3"
+services:
+  platform-builder:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - ./engines/platform-builder:/app
+    command: npm run dev
+    ports:
+      - "4001:4001"
+  execution:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - ./engines/execution:/app
+    command: npm run dev
+    ports:
+      - "4002:4002"
+  vault:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - ./engines/vault:/app
+    command: npm run dev
+    ports:
+      - "4003:4003"
+  gateway:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - ./gateway:/app
+    command: npm run dev
+    ports:
+      - "4000:4000"
+    depends_on:
+      - platform-builder
+      - execution
+      - vault

--- a/engines/execution/codex-todo.md
+++ b/engines/execution/codex-todo.md
@@ -1,7 +1,5 @@
 ## TODO
 - [x] Implement basic action runner and /execute endpoint
 - [x] Provide lockfile/offline npm install instructions
-- [ ] Integrate with Vault engine for credential fetching via GET /vault/token/:project/:service
-- [ ] Support additional actions beyond log_message
 - [x] Integrate with Vault engine for credential fetching via GET /vault/token/:project/:service
 - [x] Support additional actions beyond log_message (added send_slack)

--- a/engines/platform-builder/codex-todo.md
+++ b/engines/platform-builder/codex-todo.md
@@ -1,7 +1,5 @@
 ## TODO
 - [x] Create basic Express server with /builder/create endpoint
 - [x] Provide lockfile/offline instructions so npm install works
-- [ ] Add validation schema for Blueprint interface
-- [ ] Expand prompt parsing to support multiple actions
 - [x] Add validation schema for Blueprint interface
 - [x] Expand prompt parsing to support multiple actions

--- a/gateway/codex-todo.md
+++ b/gateway/codex-todo.md
@@ -1,8 +1,5 @@
 ## TODO
 - [x] Implement Gateway Express server with basic routing
 - [x] Provide lockfile/offline instructions so npm install works
-
-- [ ] Add /gateway/run-blueprint endpoint to orchestrate platform execution
-- [ ] Iterate over blueprint actions and call Execution engine sequentially
 - [x] Add /gateway/run-blueprint endpoint to orchestrate platform execution
 - [x] Iterate over blueprint actions and call Execution engine sequentially


### PR DESCRIPTION
## Summary
- add docker compose file with services for each engine
- document compose usage and cleanup TODO lists
- mark executed actions in PROPOSED_ACTIONS_LOG
- update SYSTEM_STATE

## Testing
- `node --test tests`

------
https://chatgpt.com/codex/tasks/task_e_6887bd493878832eb74ed34eadd818e9