### PR TITLE
Add codex-todo format guide

### DIFF
--- a/CODEX_TODO_FORMAT.md
+++ b/CODEX_TODO_FORMAT.md
@@ -1,0 +1,42 @@
+# codex-todo Format Guide
+
+This document defines the standard structure for all `codex-todo.md` files used across the PURAIFY repository.
+
+## Sections
+
+A todo file contains two main sections:
+
+1. `## TODO` – a checklist of tasks for that engine or the root project.
+2. `## Proposed Actions` – environment or configuration changes that require approval.
+
+### TODO Items
+
+- Use Markdown checkboxes: `- [ ]` for open tasks and `- [x]` for completed ones.
+- Keep each task concise and actionable.
+- Optional tags can be appended for clarity:
+  - `🔧 Requires human` – task needs human input or permission.
+  - `🌐 External constraint` – blocked by network or other external factors.
+- Once a task is done, mark it with `[x]` and keep it for history until the file is cleaned up.
+
+### Proposed Actions
+
+This section tracks environment or configuration updates. Each entry should follow:
+
+```
+- [PA<n>] Description. Impact: <short impact>. **Status: Proposed/Approved/Executed**
+```
+
+Mirror each proposal in `PROPOSED_ACTIONS_LOG.md` with the same ID. Update both locations when the status changes.
+
+## Example
+
+```markdown
+## TODO
+- [ ] Add /vault/rotate-token endpoint
+- [ ] Document token schema 🔧 Requires human
+
+## Proposed Actions
+- [PA4] Introduce Redis for Vault storage. Impact: persistent tokens. **Status: Proposed**
+```
+
+Following this format ensures automated tools and human contributors can track progress consistently across all engines.

--- a/PROPOSED_ACTIONS_LOG.md
+++ b/PROPOSED_ACTIONS_LOG.md
@@ -4,6 +4,6 @@ This file records environment and configuration changes proposed by Codex. Each 
 
 | ID  | Date       | Description                            | Status   | Approver | Notes                   |
 |-----|------------|------------------------------------|----------|----------|-------------------------|
-| PA1 | 2025-07-28 | Create codex-todo format guide across engines | Approved | CEO      | Approved on 2025-07-28  |
+| PA1 | 2025-07-28 | Create codex-todo format guide across engines | Executed | CEO      | Executed on 2025-07-28  |
 | PA2 | 2025-07-28 | Add docker-compose services for engines        | Executed | CEO      | Executed on 2025-07-28  |
 | PA3 | 2025-07-28 | Introduce Node test runner setup via ts-node   | Executed | CEO      | Executed on 2025-07-28  |

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ puraify/
 ├── SYSTEM_RULES.md                 ← High-level system policies
 ├── codex-questions.md              ← Architecture question log
 ├── codex-todo.md                   ← Global tasks
+├── CODEX_TODO_FORMAT.md            ← Standard todo file format
 ├── README.md                       ← You are here — main project overview
 ```
 

--- a/codex-todo.md
+++ b/codex-todo.md
@@ -1,7 +1,7 @@
 ## TODO
 - [x] Create ENGINE_DEPENDENCIES.md
 - [x] Create NAMESPACE_MAP.md
-- [ ] Define standard codex-todo format across engines
+- [x] Define standard codex-todo format across engines
 - [x] Populate ENGINES_INDEX.md with current engines and statuses
 - [x] Expand ENGINE_DEPENDENCIES.md for Platform Builder, Execution, and Gateway
 - [x] Flesh out NAMESPACE_MAP.md with real modules and routes
@@ -19,7 +19,7 @@
 
 Refer to `PROPOSED_ACTIONS_LOG.md` for the historical record.
 
-- [PA1] Establish a standard format guide for `codex-todo.md` files across engines. Rationale: ensure consistency for automated parsing. Impact: documentation only. **Status: Proposed**
+- [PA1] Establish a standard format guide for `codex-todo.md` files across engines. Rationale: ensure consistency for automated parsing. Impact: documentation only. **Status: Executed**
 - [PA2] Populate `docker-compose.yml` with services for each engine to simplify local development. Impact: easier startup. **Status: Executed**
 - [PA3] Add minimal test infrastructure using Node's built-in test runner with `ts-node` loader. Impact: enable basic CI testing. **Status: Executed**
 


### PR DESCRIPTION
## Summary
- document standard codex-todo.md structure
- link new CODEX_TODO_FORMAT doc in README project structure
- mark todo item complete and update proposed action status
- log executed action in PROPOSED_ACTIONS_LOG

## Testing
- `npm test` in engines/vault
- `npm test` in engines/platform-builder
- `npm test` in engines/execution
- `npm test` in gateway

------
https://chatgpt.com/codex/tasks/task_e_6887c72f3b94832e8a460457b9604d0c