### PR TITLE
Improve test usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ puraify/
 ├── README.md                       ← You are here — main project overview
 ```
 
+Automated tests for each engine live under `tests/<engine>/` and can be run with `npm test` inside the respective engine folder.
+
 Each engine is self-contained, and its README defines its APIs, responsibilities, and integration points.
 
 ---
@@ -109,6 +111,7 @@ To start working on the project:
    ```bash
    npm install
    npm run dev
+   npm test
    ```
 3. Use the Gateway to connect everything (`docker-compose up` to run all engines)
 

--- a/engines/execution/README.md
+++ b/engines/execution/README.md
@@ -32,6 +32,7 @@ Requires Node.js v20+.
 ```bash
 npm ci
 npm run dev
+npm test
 ```
 
 > Use `npm ci --prefer-offline` if installing without internet access.

--- a/engines/execution/package.json
+++ b/engines/execution/package.json
@@ -12,7 +12,7 @@
     "dev": "ts-node src/index.ts",
     "start": "node dist/index.js",
     "build": "tsc",
-    "test": "node --test"
+    "test": "node --test ../../tests/execution"
   },
   "devDependencies": {
     "@types/express": "^5.0.3"

--- a/engines/platform-builder/README.md
+++ b/engines/platform-builder/README.md
@@ -33,6 +33,7 @@ Requires Node.js v20+.
 ```bash
 npm ci
 npm run dev
+npm test
 ```
 
 > Use `npm ci --prefer-offline` if installing without internet access.

--- a/engines/platform-builder/package.json
+++ b/engines/platform-builder/package.json
@@ -12,7 +12,7 @@
     "dev": "ts-node src/index.ts",
     "start": "node dist/index.js",
     "build": "tsc",
-    "test": "node --test"
+    "test": "node --test ../../tests/platform-builder"
   },
   "devDependencies": {
     "@types/express": "^5.0.3"

--- a/engines/vault/README.md
+++ b/engines/vault/README.md
@@ -31,6 +31,7 @@ Requires Node.js v20+.
 ```bash
 npm ci
 npm run dev
+npm test
 ```
 
 > Use `npm ci --prefer-offline` if installing without internet access.

--- a/engines/vault/package.json
+++ b/engines/vault/package.json
@@ -12,7 +12,7 @@
     "dev": "ts-node src/index.ts",
     "start": "node dist/index.js",
     "build": "tsc",
-    "test": "node --test"
+    "test": "node --test ../../tests/vault"
   },
   "devDependencies": {
     "@types/express": "^5.0.3"

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -28,6 +28,7 @@ gateway/
 └── src/
     └── index.ts
 ```
+Tests for this engine live in `tests/gateway/`.
 ## 🚀 Development Setup
 
 Requires Node.js v20+.
@@ -35,6 +36,7 @@ Requires Node.js v20+.
 ```bash
 npm ci
 npm run dev
+npm test
 ```
 
 > Use `npm ci --prefer-offline` if installing without internet access.

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -13,7 +13,7 @@
     "dev": "ts-node src/index.ts",
     "start": "node dist/index.js",
     "build": "tsc",
-    "test": "node --test"
+    "test": "node --test ../tests/gateway"
   },
   "devDependencies": {
     "@types/express": "^5.0.3"


### PR DESCRIPTION
## Summary
- wire test scripts to run engine tests by path
- document npm test usage in all READMEs
- note location of test folders in root README

## Testing
- `npm test` in engines/platform-builder
- `npm test` in engines/execution
- `npm test` in engines/vault
- `npm test` in gateway

------
https://chatgpt.com/codex/tasks/task_e_6887ce10bc7c832e908aafb8930e35fb