### PR TITLE
Implement POST /vault/token endpoint

### DIFF
--- a/ENGINE_DEPENDENCIES.md
+++ b/ENGINE_DEPENDENCIES.md
@@ -3,7 +3,7 @@
 - depends on: execution (/exec/token/verify)
 
 ### platform-builder
-- depends on: vault (/vault/token/store)
+- depends on: vault (/vault/token)
 - depends on: gateway (/gateway/route)
 - provides: blueprint generation to gateway (/builder/create)
 
@@ -27,7 +27,7 @@
 - depends on: vault (/vault/token/verify)
 
 ### integration-manager
-- depends on: vault (/vault/token/store)
+- depends on: vault (/vault/token)
 
 ### monitoring-logs-engine
 - depends on: execution (/exec/logs)

--- a/NAMESPACE_MAP.md
+++ b/NAMESPACE_MAP.md
@@ -29,7 +29,7 @@
 
 | Engine           | Route                     | Notes                          |
 |------------------|---------------------------|--------------------------------|
-| vault            | /vault/store              | Token & secrets API            |
+| vault            | /vault/token              | Token & secrets API            |
 | platform-builder | /builder/create           | Platform creation & updates    |
 | execution        | /execute                  | Run actions & flows            |
 | gateway          | /gateway/*                    | API gateway router             |

--- a/SYSTEM_STATE.md
+++ b/SYSTEM_STATE.md
@@ -1,7 +1,7 @@
 # PURAIFY — Live System State
 
 This file documents the current **real-time** state of the PURAIFY platform.  
-As of now, most engines only contain scaffold code. The Vault Engine exposes a working `POST /vault/store` endpoint and plans to add `GET /vault/token/:project/:service`.
+As of now, most engines only contain scaffold code. The Vault Engine exposes working `POST /vault/store` and `POST /vault/token` endpoints and a `GET /vault/token/:project/:service` lookup route.
 ---
 
 ## 🧱 System Build Status
@@ -35,7 +35,7 @@ As of now, most engines only contain scaffold code. The Vault Engine exposes a w
 | Engine            | APIs            | Status       |
 |-------------------|------------------|--------------|
 | Platform Builder  | `POST /builder/create` | 🟢 In Progress |
-| Vault Engine      | `POST /vault/store`, `GET /vault/token/:project/:service`, `DELETE /vault/token/:project/:service` | 🟢 In Progress |
+| Vault Engine      | `POST /vault/store`, `POST /vault/token`, `GET /vault/token/:project/:service`, `DELETE /vault/token/:project/:service` | 🟢 In Progress |
 | Execution Engine  | `POST /execute` | 🟢 In Progress |
 | Gateway           | `POST /gateway/build-platform`, `POST /gateway/execute-action`, `POST /gateway/store-token`, `POST /gateway/run-blueprint` | 🟢 In Progress |
 
@@ -56,6 +56,7 @@ As of now, most engines only contain scaffold code. The Vault Engine exposes a w
 
 - [x] Implemented `POST /vault/store` endpoint for Vault Engine
 - [x] Add `GET /vault/token/:project/:service` endpoint
+- [x] Added `POST /vault/token` endpoint for simplified storage
 - [x] Begin Gateway skeleton with routing between engines
 - [x] Define actual blueprint structure for Platform Builder (initial interface implemented)
 - [x] Add internal dev/test setup (e.g., nodemon, tsconfig)
@@ -71,7 +72,7 @@ As of now, most engines only contain scaffold code. The Vault Engine exposes a w
 
 ## 🧠 Codex Notes Map
 engines/vault/src/index.ts:
-  Note: ✅ GET and DELETE endpoints implemented
+  Note: ✅ GET, POST and DELETE endpoints implemented
 engines/platform-builder/src/index.ts:
   Note: ✅ Basic server with validation and multi-action parsing implemented
 engines/execution/src/index.ts:

--- a/engines/vault/README.md
+++ b/engines/vault/README.md
@@ -66,6 +66,9 @@ Example Flow:
 
 Stores a token for a specific service and project.
 
+> This legacy endpoint remains for compatibility. New integrations should
+> use `POST /vault/token` which uses the simplified `project` field.
+
 **Request Body**
 
 ```json
@@ -84,7 +87,7 @@ Stores a token for a specific service and project.
 }
 ```
 
-### `POST /vault/token` *(planned)*
+### `POST /vault/token`
 
 ```
 POST /vault/token

--- a/engines/vault/codex-todo.md
+++ b/engines/vault/codex-todo.md
@@ -2,3 +2,4 @@
 - [x] Implement GET /vault/token/:project/:service endpoint
 - [x] Provide lockfile or offline instructions so npm install works
 - [x] Implement DELETE /vault/token/:project/:service endpoint
+- [x] Add POST /vault/token endpoint for standard token storage

--- a/engines/vault/src/index.ts
+++ b/engines/vault/src/index.ts
@@ -18,6 +18,19 @@ app.post('/vault/store', (req: Request, res: Response) => {
   return res.json({ success: true });
 });
 
+// Preferred endpoint using "project" for consistency
+app.post('/vault/token', (req: Request, res: Response) => {
+  const { project, service, token } = req.body || {};
+  if (!project || !service || !token) {
+    return res.status(400).json({ error: 'project, service and token are required' });
+  }
+  if (!tokenStore[project]) {
+    tokenStore[project] = {};
+  }
+  tokenStore[project][service] = token;
+  return res.json({ success: true });
+});
+
 app.get('/vault/token/:project/:service', (req: Request, res: Response) => {
   const { project, service } = req.params;
   const token = tokenStore[project]?.[service];

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -28,7 +28,7 @@ app.post('/gateway/execute-action', async (req: Request, res: Response) => {
 
 app.post('/gateway/store-token', async (req: Request, res: Response) => {
   try {
-    const response = await axios.post(`${VAULT_URL}/vault/store`, req.body);
+    const response = await axios.post(`${VAULT_URL}/vault/token`, req.body);
     res.json(response.data);
   } catch (err: any) {
     res.status(500).json({ error: err.message });


### PR DESCRIPTION
## Summary
- add `/vault/token` POST route to Vault engine
- update Gateway to call new Vault route
- document new endpoint in Vault README
- sync SYSTEM_STATE, engine docs, namespace and dependencies
- mark todo completed for Vault engine

## Testing
- `npm test` in `engines/platform-builder`
- `npm test` in `engines/execution`
- `npm test` in `engines/vault`
- `npm test` in `gateway`

------
https://chatgpt.com/codex/tasks/task_e_6887d8e86554832eb932311813c2e3a4