### PR TITLE
Improve gateway run-blueprint

### DIFF
--- a/SYSTEM_STATE.md
+++ b/SYSTEM_STATE.md
@@ -65,7 +65,7 @@ As of now, most engines only contain scaffold code. The Vault Engine exposes wor
 
 ---
 ## 🔄 Next Integration Steps
-- Add `/gateway/run-blueprint` route to orchestrate builder output and sequential execution.
+- `/gateway/run-blueprint` now executes all actions sequentially and returns a results array even if some actions fail.
 - Execution Engine must fetch tokens from Vault via `GET /vault/token/:project/:service` when actions need credentials.
 - Gateway orchestrates flow; Execution handles token retrieval; Vault serves tokens; Platform Builder supplies the blueprint.
 
@@ -78,7 +78,7 @@ engines/platform-builder/src/index.ts:
 engines/execution/src/index.ts:
   Note: ✅ Action runner with send_slack token retrieval; returns 404 if token missing
 gateway/src/index.ts:
-  Note: ✅ Gateway routing implemented; run-blueprint orchestration added
+  Note: ✅ Gateway routing implemented; run-blueprint now continues after failures
 integration-design:
   Note: ❓ Should Gateway or Execution Engine fetch Vault tokens during action execution?
 root-level:

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -90,6 +90,8 @@ Sends token to Vault Engine for storage.
 POST /gateway/run-blueprint
 ```
 Iterates over a blueprint's actions and invokes the Execution Engine sequentially.
+Execution continues even if an individual action fails; the response includes a
+`results` array with success or error entries for each action.
 
 > More endpoints may be added as new capabilities emerge (validation, feedback, logs, etc.)
 

--- a/gateway/codex-todo.md
+++ b/gateway/codex-todo.md
@@ -4,4 +4,4 @@
 - [x] Add /gateway/run-blueprint endpoint to orchestrate platform execution
 - [x] Iterate over blueprint actions and call Execution engine sequentially
 - [x] Document codex-todo.md in README engine structure
-- [ ] Handle failures in run-blueprint without aborting entire run
+- [x] Handle failures in run-blueprint without aborting entire run

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -48,9 +48,9 @@ app.post('/gateway/run-blueprint', async (req: Request, res: Response) => {
         project,
         params: action.params
       });
-      results.push(response.data);
+      results.push({ status: 'success', data: response.data });
     } catch (err: any) {
-      return res.status(500).json({ error: err.message });
+      results.push({ status: 'error', error: err.message });
     }
   }
   res.json({ results });

--- a/tests/gateway/codex-test-todo.md
+++ b/tests/gateway/codex-test-todo.md
@@ -1,3 +1,5 @@
 ## Planned Tests
 - [ ] Integration test for full pipeline via Gateway 🔧 Requires dependencies
   - Blocked: npm install cannot run (no internet)
+- [ ] Validate `/gateway/run-blueprint` continues after failed actions
+  - Blocked: supertest not available offline


### PR DESCRIPTION
## Summary
- continue execution when an action fails in `run-blueprint`
- document new behavior in gateway README
- mark todo completed for failure handling
- log new planned test for run-blueprint
- update system state notes

## Testing
- `npm test` in engines/platform-builder
- `npm test` in engines/execution
- `npm test` in engines/vault
- `npm test` in gateway

------
https://chatgpt.com/codex/tasks/task_e_6887e7ddfbdc832ea188647be3965dc0