### PR TITLE
Add human task tracking workflow

### DIFF
--- a/CONTRIBUTION_PROTOCOL.md
+++ b/CONTRIBUTION_PROTOCOL.md
@@ -256,6 +256,10 @@ Format example:
 This root-level file collects system-wide tasks across engines and protocol updates. Engine-specific items should remain in each engine’s own `codex-todo.md` file.
 
 Refer to `CODEX_TODO_FORMAT.md` for the required sections and formatting, including how to track proposed actions. Mirror any proposals in `PROPOSED_ACTIONS_LOG.md` before seeking approval.
+🧑‍💻 New File: human-todo.md
+This separate root-level file tracks tasks that require manual intervention, such as installing packages, configuring environments, or resolving permissions.
+Codex should add items here when blocked by external constraints, and humans should check them off once resolved.
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ puraify/
 ├── SYSTEM_RULES.md                 ← High-level system policies
 ├── codex-questions.md              ← Architecture question log
 ├── codex-todo.md                   ← Global tasks
+├── human-todo.md              ← Manual setup tasks
 ├── CODEX_TODO_FORMAT.md            ← Standard todo file format
 ├── README.md                       ← You are here — main project overview
 ```
@@ -137,6 +138,7 @@ documentation rules. The latest implementation snapshot is kept in
 [SYSTEM_STATE.md](SYSTEM_STATE.md).
 Environment or configuration updates follow the "Proposed Actions" workflow defined in
 `CONTRIBUTION_PROTOCOL.md` and logged in `PROPOSED_ACTIONS_LOG.md`.
+Manual setup tasks that need human attention are tracked in `human-todo.md`.
 
 ---
 

--- a/SYSTEM_STATE.md
+++ b/SYSTEM_STATE.md
@@ -83,6 +83,7 @@ integration-design:
   Note: ❓ Should Gateway or Execution Engine fetch Vault tokens during action execution?
 root-level:
   Note: ENGINE_DEPENDENCIES.md, NAMESPACE_MAP.md and codex-todo.md added for cross-engine tracking. Engine-level codex-todo format expected.
+  and human-todo.md added for manual environment tasks
 
 ---
 

--- a/human-todo.md
+++ b/human-todo.md
@@ -1,0 +1,6 @@
+## TODO
+- [ ] Provide a reliable offline method for running `npm install` across all engines 🔧 Requires human
+- [ ] Configure environment or proxy to allow test dependencies to install 🔧 Requires human
+
+## Completed
+


### PR DESCRIPTION
## Summary
- add new `human-todo.md` for environment setup tasks
- document human todo workflow in CONTRIBUTION_PROTOCOL
- reference `human-todo.md` in README project structure and contributing section
- note the new file in SYSTEM_STATE

## Testing
- `npm test` (fails: no test specified)
- `cd engines/vault && npm test`
- `cd engines/platform-builder && npm test`
- `cd engines/execution && npm test`
- `cd gateway && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6887fd21750c832eba1d7a5e6ecd6e1a