### PR TITLE
Documentation updates

### DIFF
--- a/ENGINE_DEPENDENCIES.md
+++ b/ENGINE_DEPENDENCIES.md
@@ -1,22 +1,18 @@
 ### vault
-- depends on: platform-builder (/platform/blueprint/:id)
-- depends on: execution (/exec/token/verify)
+Currently standalone; no direct engine dependencies.
 
 ### platform-builder
-- depends on: vault (/vault/token)
-- depends on: gateway (/gateway/route)
-- provides: blueprint generation to gateway (/builder/create)
+Provides blueprint generation to Gateway via `/builder/create`.
+Currently has no runtime dependencies on other engines.
 
 ### execution
-- depends on: vault (/vault/token/fetch)
-- depends on: platform-builder (/platform/blueprint/:id)
-- depends on: gateway (/gateway/route)
-- provides: action execution via /execute
+- depends on: vault (`/vault/token/:project/:service`)
+- provides: action execution via `/execute`
 
 ### gateway
-- depends on: vault (/vault/token/validate)
-- depends on: platform-builder (/builder/create)
-- depends on: execution (/execute)
+- depends on: vault (`/vault/token` & `/vault/token/:project/:service`)
+- depends on: platform-builder (`/builder/create`)
+- depends on: execution (`/execute`)
 
 ### knowledge-engine
 - depends on: vault (/vault/token/fetch)

--- a/NAMESPACE_MAP.md
+++ b/NAMESPACE_MAP.md
@@ -31,11 +31,17 @@
 
 | Engine           | Route                     | Notes                          |
 |------------------|---------------------------|--------------------------------|
-| vault            | /vault/token              | Token & secrets API            |
+| vault            | /vault/store              | Legacy token storage route |
+| vault            | /vault/token              | Create token entry |
+| vault            | /vault/token/:project/:service | Fetch stored token |
+| vault            | DELETE /vault/token/:project/:service | Remove token |
 | platform-builder | /builder/create           | Platform creation & updates    |
 | execution        | /execute                  | Run actions & flows            |
-| gateway          | /gateway/*                    | API gateway router
-| gateway          | /gateway/run-blueprint           | Orchestrates sequential execution
+| gateway          | /gateway/*                    | API gateway router |
+| gateway          | /gateway/build-platform       | Passes prompt to Builder |
+| gateway          | /gateway/execute-action       | Runs single action via Execution |
+| gateway          | /gateway/store-token          | Saves credentials via Vault |
+| gateway          | /gateway/run-blueprint        | Orchestrates sequential execution |
 | knowledge        | /knowledge/blueprint      | Planned                       |
 | validation       | /validation/check         | Planned                       |
 | integration      | /integration/connect      | Planned                       |

--- a/SYSTEM_STATE.md
+++ b/SYSTEM_STATE.md
@@ -91,7 +91,8 @@ root-level:
 
 The PURAIFY project is in the **early development phase**, with initial endpoints implemented for each engine.
 The next step is to expand features, add validation, and integrate across engines.
+Documentation updated for engine dependencies and namespace mapping to reflect current implementation.
 
 ---
 
-Last updated: July 29, 2025
+Last updated: July 30, 2025

--- a/docs/codex-todo.md
+++ b/docs/codex-todo.md
@@ -10,8 +10,7 @@
 
 - [x] Document gateway's `codex-todo.md` in both root README and gateway README
 - [ ] Create integration tests that run blueprint creation via Gateway and execute actions 🌐 External constraint (npm install blocked)
-- [ ] Review ENGINE_DEPENDENCIES.md for accuracy against code implementation
-- [ ] Expand NAMESPACE_MAP.md with file references as new engines are added
+- [x] Review ENGINE_DEPENDENCIES.md for accuracy against code implementation
 - [x] Expand NAMESPACE_MAP.md with file references as new engines are added
 
 


### PR DESCRIPTION
## Summary
- correct ENGINE_DEPENDENCIES.md
- expand NAMESPACE_MAP routes
- mark completed tasks in codex-todo
- update SYSTEM_STATE summary

## Testing
- `npm test --silent` in engines/vault
- `npm test --silent` in engines/execution
- `npm test --silent` in engines/platform-builder
- `npm test --silent` in gateway

------
https://chatgpt.com/codex/tasks/task_e_68880fd99654832e8a0d607263e3dfc9