### PR TITLE
Implement Slack API call

### DIFF
--- a/ENGINE_DEPENDENCIES.md
+++ b/ENGINE_DEPENDENCIES.md
@@ -1,22 +1,19 @@
 ### vault
-- depends on: platform-builder (/platform/blueprint/:id)
-- depends on: execution (/exec/token/verify)
+Currently standalone; no direct engine dependencies.
 
 ### platform-builder
-- depends on: vault (/vault/token)
-- depends on: gateway (/gateway/route)
-- provides: blueprint generation to gateway (/builder/create)
+Provides blueprint generation to Gateway via `/builder/create`.
+Currently has no runtime dependencies on other engines.
 
 ### execution
-- depends on: vault (/vault/token/fetch)
-- depends on: platform-builder (/platform/blueprint/:id)
-- depends on: gateway (/gateway/route)
-- provides: action execution via /execute
+- depends on: vault (`/vault/token/:project/:service`)
+- depends on: Slack API (`chat.postMessage`)
+- provides: action execution via `/execute`
 
 ### gateway
-- depends on: vault (/vault/token/validate)
-- depends on: platform-builder (/builder/create)
-- depends on: execution (/execute)
+- depends on: vault (`/vault/token` & `/vault/token/:project/:service`)
+- depends on: platform-builder (`/builder/create`)
+- depends on: execution (`/execute`)
 
 ### knowledge-engine
 - depends on: vault (/vault/token/fetch)

--- a/NAMESPACE_MAP.md
+++ b/NAMESPACE_MAP.md
@@ -31,11 +31,17 @@
 
 | Engine           | Route                     | Notes                          |
 |------------------|---------------------------|--------------------------------|
-| vault            | /vault/token              | Token & secrets API            |
+| vault            | /vault/store              | Legacy token storage route |
+| vault            | /vault/token              | Create token entry |
+| vault            | /vault/token/:project/:service | Fetch stored token |
+| vault            | DELETE /vault/token/:project/:service | Remove token |
 | platform-builder | /builder/create           | Platform creation & updates    |
 | execution        | /execute                  | Run actions & flows            |
-| gateway          | /gateway/*                    | API gateway router
-| gateway          | /gateway/run-blueprint           | Orchestrates sequential execution
+| gateway          | /gateway/*                    | API gateway router |
+| gateway          | /gateway/build-platform       | Passes prompt to Builder |
+| gateway          | /gateway/execute-action       | Runs single action via Execution |
+| gateway          | /gateway/store-token          | Saves credentials via Vault |
+| gateway          | /gateway/run-blueprint        | Orchestrates sequential execution |
 | knowledge        | /knowledge/blueprint      | Planned                       |
 | validation       | /validation/check         | Planned                       |
 | integration      | /integration/connect      | Planned                       |

--- a/SYSTEM_STATE.md
+++ b/SYSTEM_STATE.md
@@ -45,7 +45,7 @@ As of now, most engines only contain scaffold code. The Vault Engine persists to
 
 | Integration    | Status     | Notes |
 |----------------|------------|-------|
-| Slack          | 🔲 Not Yet | Placeholder defined in Execution README |
+| Slack          | 🟡 Partial | send_slack action now posts via Slack API |
 | Notion         | 🔲 Not Yet | Planned |
 | Google Sheets  | 🔲 Not Yet | Planned |
 | Email (SMTP)   | 🔲 Not Yet | Planned |
@@ -76,7 +76,7 @@ engines/vault/src/index.ts:
 engines/platform-builder/src/index.ts:
   Note: ✅ Basic server with validation; parser supports "and", "then", comma lists
 engines/execution/src/index.ts:
-  Note: ✅ Action runner with send_slack token retrieval; returns 404 if token missing
+  Note: ✅ send_slack now posts to Slack API; returns 404 if token missing
 gateway/src/index.ts:
   Note: ✅ Gateway routing implemented; run-blueprint now continues after failures
 integration-design:
@@ -91,7 +91,8 @@ root-level:
 
 The PURAIFY project is in the **early development phase**, with initial endpoints implemented for each engine.
 The next step is to expand features, add validation, and integrate across engines.
+Documentation updated for engine dependencies and namespace mapping to reflect current implementation.
 
 ---
 
-Last updated: July 29, 2025
+Last updated: July 31, 2025

--- a/docs/codex-todo.md
+++ b/docs/codex-todo.md
@@ -10,8 +10,7 @@
 
 - [x] Document gateway's `codex-todo.md` in both root README and gateway README
 - [ ] Create integration tests that run blueprint creation via Gateway and execute actions 🌐 External constraint (npm install blocked)
-- [ ] Review ENGINE_DEPENDENCIES.md for accuracy against code implementation
-- [ ] Expand NAMESPACE_MAP.md with file references as new engines are added
+- [x] Review ENGINE_DEPENDENCIES.md for accuracy against code implementation
 - [x] Expand NAMESPACE_MAP.md with file references as new engines are added
 
 

--- a/engines/execution/README.md
+++ b/engines/execution/README.md
@@ -130,8 +130,9 @@ Error example:
 
 ## 🚧 Development Notes
 
-- Basic Vault integration implemented for the `send_slack` action. The engine fetches a token via `GET /vault/token/:project/slack` and logs the action.
-- Missing tokens now return a clear `404` error instead of a generic `500`.
+- `send_slack` now performs a real API request via `chat.postMessage`. The URL can be overridden with the `SLACK_API_URL` env var for testing.
+- Vault integration fetches tokens via `GET /vault/token/:project/slack`.
+- Missing tokens return a clear `404` error instead of a generic `500`.
 - The engine will evolve to support retries, fallback handlers, and async task queues.
 - Logs should be structured and sent to Logs Engine in the future.
 

--- a/engines/execution/codex-todo.md
+++ b/engines/execution/codex-todo.md
@@ -4,4 +4,4 @@
 - [x] Integrate with Vault engine for credential fetching via GET /vault/token/:project/:service
 - [x] Support additional actions beyond log_message (added send_slack)
 - [x] Return a clear error when Vault token is missing (404)
-- [ ] Implement real Slack API call using axios
+- [x] Implement real Slack API call using axios

--- a/engines/execution/src/index.ts
+++ b/engines/execution/src/index.ts
@@ -1,5 +1,6 @@
 import express, { Request, Response } from "express";
 import axios from "axios";
+import { sendSlackMessage } from "./slack";
 
 const app = express();
 app.use(express.json());
@@ -28,8 +29,10 @@ app.post('/execute', async (req: Request, res: Response) => {
         const vaultUrl = process.env.VAULT_URL || 'http://localhost:4003';
         const { data } = await axios.get(`${vaultUrl}/vault/token/${project}/slack`);
         const token = data.token;
-        console.log(`Would send Slack message '${params?.message}' with token ${token}`);
-        return res.json({ status: 'success' });
+        const channel = params?.channel || '#general';
+        const message = params?.message || '';
+        const slackRes = await sendSlackMessage(token, channel, message);
+        return res.json({ status: 'success', data: slackRes });
       } catch (err: any) {
         if (axios.isAxiosError(err) && err.response?.status === 404) {
           return res.status(404).json({ status: 'error', message: 'Slack token not found' });

--- a/engines/execution/src/slack.ts
+++ b/engines/execution/src/slack.ts
@@ -1,0 +1,20 @@
+import axios from 'axios';
+
+export interface SlackResponse {
+  ok: boolean;
+  [key: string]: any;
+}
+
+export async function sendSlackMessage(token: string, channel: string, text: string): Promise<SlackResponse> {
+  const url = process.env.SLACK_API_URL || 'https://slack.com/api/chat.postMessage';
+  const { data } = await axios.post(url, { channel, text }, {
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json'
+    }
+  });
+  if (!data.ok) {
+    throw new Error(data.error || 'Slack API error');
+  }
+  return data;
+}

--- a/tests/execution/sample.test.js
+++ b/tests/execution/sample.test.js
@@ -1,2 +1,8 @@
 import assert from 'assert';
+import fs from 'fs';
+import path from 'path';
+
+// Basic sanity check and presence of new Slack module
+const slackPath = path.join(new URL('.', import.meta.url).pathname, '..', '..', 'engines', 'execution', 'src', 'slack.ts');
+assert.ok(fs.existsSync(slackPath));
 assert.equal(1,1);


### PR DESCRIPTION
## Summary
- implement Slack messaging helper in Execution engine
- wire send_slack action to use real Slack API
- document Slack integration and update codex-todo
- track Slack integration status in SYSTEM_STATE
- add sanity test for slack module

## Testing
- `npm test --silent` in engines/vault
- `npm test --silent` in engines/execution
- `npm test --silent` in engines/platform-builder
- `npm test --silent` in gateway

------
https://chatgpt.com/codex/tasks/task_e_68880fd99654832e8a0d607263e3dfc9