### PR TITLE
Implement basic Slack API call in execution engine

### DIFF
--- a/SYSTEM_STATE.md
+++ b/SYSTEM_STATE.md
@@ -45,7 +45,7 @@ As of now, most engines only contain scaffold code. The Vault Engine persists to
 
 | Integration    | Status     | Notes |
 |----------------|------------|-------|
-| Slack          | 🔲 Not Yet | Placeholder defined in Execution README |
+| Slack          | 🟢 Basic   | `send_slack` posts via Slack API |
 | Notion         | 🔲 Not Yet | Planned |
 | Google Sheets  | 🔲 Not Yet | Planned |
 | Email (SMTP)   | 🔲 Not Yet | Planned |
@@ -76,7 +76,7 @@ engines/vault/src/index.ts:
 engines/platform-builder/src/index.ts:
   Note: ✅ Basic server with validation; parser supports "and", "then", comma lists
 engines/execution/src/index.ts:
-  Note: ✅ Action runner with send_slack token retrieval; returns 404 if token missing
+  Note: ✅ send_slack now calls Slack API via fetch; token fetched from Vault and 404 when missing
 gateway/src/index.ts:
   Note: ✅ Gateway routing implemented; run-blueprint now continues after failures
 integration-design:
@@ -95,4 +95,4 @@ Documentation updated for engine dependencies and namespace mapping to reflect c
 
 ---
 
-Last updated: July 30, 2025
+Last updated: July 29, 2025

--- a/engines/execution/README.md
+++ b/engines/execution/README.md
@@ -130,8 +130,8 @@ Error example:
 
 ## 🚧 Development Notes
 
-- Basic Vault integration implemented for the `send_slack` action. The engine fetches a token via `GET /vault/token/:project/slack` and logs the action.
-- Missing tokens now return a clear `404` error instead of a generic `500`.
+- `send_slack` now performs a real Slack API call via `chat.postMessage`. The engine fetches a token using `GET /vault/token/:project/slack` and posts the message with Node's built‑in `fetch`.
+- Missing tokens return a clear `404` error instead of a generic `500`.
 - The engine will evolve to support retries, fallback handlers, and async task queues.
 - Logs should be structured and sent to Logs Engine in the future.
 

--- a/engines/execution/codex-todo.md
+++ b/engines/execution/codex-todo.md
@@ -4,4 +4,4 @@
 - [x] Integrate with Vault engine for credential fetching via GET /vault/token/:project/:service
 - [x] Support additional actions beyond log_message (added send_slack)
 - [x] Return a clear error when Vault token is missing (404)
-- [ ] Implement real Slack API call using axios
+- [x] Implement real Slack API call using fetch instead of axios

--- a/engines/execution/src/index.ts
+++ b/engines/execution/src/index.ts
@@ -1,5 +1,4 @@
 import express, { Request, Response } from "express";
-import axios from "axios";
 
 const app = express();
 app.use(express.json());
@@ -24,16 +23,33 @@ app.post('/execute', async (req: Request, res: Response) => {
       if (!project) {
         return res.status(400).json({ status: 'error', message: 'project required' });
       }
+      if (!params?.channel || !params?.message) {
+        return res.status(400).json({ status: 'error', message: 'channel and message required' });
+      }
       try {
         const vaultUrl = process.env.VAULT_URL || 'http://localhost:4003';
-        const { data } = await axios.get(`${vaultUrl}/vault/token/${project}/slack`);
-        const token = data.token;
-        console.log(`Would send Slack message '${params?.message}' with token ${token}`);
-        return res.json({ status: 'success' });
-      } catch (err: any) {
-        if (axios.isAxiosError(err) && err.response?.status === 404) {
+        const tokenResp = await fetch(`${vaultUrl}/vault/token/${project}/slack`);
+        if (tokenResp.status === 404) {
           return res.status(404).json({ status: 'error', message: 'Slack token not found' });
         }
+        if (!tokenResp.ok) {
+          throw new Error(`Vault error: ${tokenResp.status}`);
+        }
+        const { token } = await tokenResp.json();
+        const slackResp = await fetch('https://slack.com/api/chat.postMessage', {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${token}`,
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ channel: params.channel, text: params.message })
+        });
+        const slackJson = await slackResp.json();
+        if (!slackJson.ok) {
+          return res.status(500).json({ status: 'error', message: slackJson.error });
+        }
+        return res.json({ status: 'success', data: { ts: slackJson.ts } });
+      } catch (err: any) {
         return res.status(500).json({ status: 'error', message: err.message });
       }
     }

--- a/tests/execution/codex-test-todo.md
+++ b/tests/execution/codex-test-todo.md
@@ -1,0 +1,2 @@
+## Planned Tests
+- [ ] Test send_slack posts message using mock server 🌐 External constraint (uvu not installed)


### PR DESCRIPTION
## Summary
- execution engine now calls Slack API with fetch in send_slack action
- document Slack API call in execution README
- mark Slack integration as basic in SYSTEM_STATE
- close execution todo for Slack API and add codex-test-todo for future tests

## Testing
- `npm test` *(fails: uvu not found)*

------
https://chatgpt.com/codex/tasks/task_e_688815a2e1c8832ea4ea4d0fcc3a8933