### PR TITLE
Add token listing routes to Vault

### DIFF
--- a/SYSTEM_STATE.md
+++ b/SYSTEM_STATE.md
@@ -35,7 +35,7 @@ As of now, most engines only contain scaffold code. The Vault Engine persists to
 | Engine            | APIs            | Status       |
 |-------------------|------------------|--------------|
 | Platform Builder  | `POST /builder/create` | 🟢 In Progress |
-| Vault Engine      | `POST /vault/store`, `POST /vault/token`, `GET /vault/token/:project/:service`, `DELETE /vault/token/:project/:service` | 🟢 In Progress |
+| Vault Engine      | `POST /vault/store`, `POST /vault/token`, `GET /vault/token/:project/:service`, `DELETE /vault/token/:project/:service`, `GET /vault/tokens/:project`, `GET /vault/projects` | 🟢 In Progress |
 | Execution Engine  | `POST /execute` | 🟢 In Progress |
 | Gateway           | `POST /gateway/build-platform`, `POST /gateway/execute-action`, `POST /gateway/store-token`, `POST /gateway/run-blueprint` | 🟢 In Progress |
 
@@ -72,7 +72,7 @@ As of now, most engines only contain scaffold code. The Vault Engine persists to
 
 ## 🧠 Codex Notes Map
 engines/vault/src/index.ts:
-  Note: ✅ GET, POST and DELETE endpoints implemented with encrypted token persistence to `tokens.json` when `VAULT_SECRET` is set
+  Note: ✅ GET, POST and DELETE endpoints implemented with encrypted token persistence to `tokens.json` when `VAULT_SECRET` is set. Added listing endpoints `/vault/tokens/:project` and `/vault/projects`.
 engines/platform-builder/src/index.ts:
   Note: ✅ Basic server with validation; parser supports "and", "then", comma lists
 engines/execution/src/index.ts:

--- a/engines/execution/package.json
+++ b/engines/execution/package.json
@@ -12,7 +12,7 @@
     "dev": "ts-node src/index.ts",
     "start": "node dist/index.js",
     "build": "tsc",
-    "test": "node --test ../../tests/execution"
+    "test": "node --test ../../tests/execution/*.test.js"
   },
   "devDependencies": {
     "@types/express": "^5.0.3"

--- a/engines/platform-builder/package.json
+++ b/engines/platform-builder/package.json
@@ -12,7 +12,7 @@
     "dev": "ts-node src/index.ts",
     "start": "node dist/index.js",
     "build": "tsc",
-    "test": "node --test ../../tests/platform-builder"
+    "test": "node --test ../../tests/platform-builder/*.test.js"
   },
   "devDependencies": {
     "@types/express": "^5.0.3"

--- a/engines/vault/README.md
+++ b/engines/vault/README.md
@@ -125,6 +125,16 @@ Remove stored token and update `tokens.json` accordingly.
 
 This endpoint is **implemented** in `src/index.ts` and deletes the token entry if it exists.
 
+```
+GET /vault/tokens/:project
+```
+Return all stored service tokens for the given project.
+
+```
+GET /vault/projects
+```
+List all projects that currently have tokens stored.
+
 ---
 
 ## 🛠️ Internals & Responsibilities

--- a/engines/vault/package.json
+++ b/engines/vault/package.json
@@ -12,7 +12,7 @@
     "dev": "ts-node src/index.ts",
     "start": "node dist/index.js",
     "build": "tsc",
-    "test": "node --test ../../tests/vault"
+    "test": "node --test ../../tests/vault/*.test.js"
   },
   "devDependencies": {
     "@types/express": "^5.0.3"

--- a/engines/vault/src/index.ts
+++ b/engines/vault/src/index.ts
@@ -66,6 +66,22 @@ app.delete('/vault/token/:project/:service', (req: Request, res: Response) => {
   return res.status(404).json({ error: 'Token not found' });
 });
 
+app.get('/vault/tokens/:project', (req: Request, res: Response) => {
+  const { project } = req.params;
+  if (!project) {
+    return res.status(400).json({ error: 'project required' });
+  }
+  const tokens = tokenStore[project];
+  if (!tokens) {
+    return res.status(404).json({ error: 'Project not found' });
+  }
+  return res.json({ tokens });
+});
+
+app.get('/vault/projects', (_req: Request, res: Response) => {
+  return res.json({ projects: Object.keys(tokenStore) });
+});
+
 const port = Number(process.env.PORT) || 4003;
 if (require.main === module) {
   app.listen(port, () => {

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -13,7 +13,7 @@
     "dev": "ts-node src/index.ts",
     "start": "node dist/index.js",
     "build": "tsc",
-    "test": "node --test ../tests/gateway"
+    "test": "node --test ../tests/gateway/*.test.js"
   },
   "devDependencies": {
     "@types/express": "^5.0.3"


### PR DESCRIPTION
## Summary
- add `/vault/tokens/:project` and `/vault/projects` endpoints
- document new routes in Vault README and SYSTEM_STATE
- fix engine test scripts to look for `.test.js` files

## Testing
- `npm test` *(fails: uvu not found)*
- `cd engines/vault && npm test`
- `cd ../execution && npm test`
- `cd ../platform-builder && npm test`
- `cd ../../gateway && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6888194d8ed0832eac01e65b5d115b55