### PR TITLE
Add project deletion to Vault

### DIFF
--- a/NAMESPACE_MAP.md
+++ b/NAMESPACE_MAP.md
@@ -35,6 +35,9 @@
 | vault            | /vault/token              | Create token entry |
 | vault            | /vault/token/:project/:service | Fetch stored token |
 | vault            | DELETE /vault/token/:project/:service | Remove token |
+| vault            | /vault/tokens/:project | List tokens for a project |
+| vault            | DELETE /vault/tokens/:project | Remove all tokens for a project |
+| vault            | /vault/projects | List projects with stored tokens |
 | platform-builder | /builder/create           | Platform creation & updates    |
 | execution        | /execute                  | Run actions & flows            |
 | gateway          | /gateway/*                    | API gateway router |

--- a/SYSTEM_STATE.md
+++ b/SYSTEM_STATE.md
@@ -1,7 +1,7 @@
 # PURAIFY — Live System State
 
 This file documents the current **real-time** state of the PURAIFY platform.
-As of now, most engines only contain scaffold code. The Vault Engine persists tokens to `tokens.json` (encrypted when `VAULT_SECRET` is set) and exposes working `POST /vault/store`, `POST /vault/token`, and `GET /vault/token/:project/:service` routes.
+As of now, most engines only contain scaffold code. The Vault Engine persists tokens to `tokens.json` (location overridable via `VAULT_DATA_FILE`) and exposes working token CRUD routes with AES-256 encryption when `VAULT_SECRET` is set.
 ---
 
 ## 🧱 System Build Status
@@ -35,7 +35,7 @@ As of now, most engines only contain scaffold code. The Vault Engine persists to
 | Engine            | APIs            | Status       |
 |-------------------|------------------|--------------|
 | Platform Builder  | `POST /builder/create` | 🟢 In Progress |
-| Vault Engine      | `POST /vault/store`, `POST /vault/token`, `GET /vault/token/:project/:service`, `DELETE /vault/token/:project/:service`, `GET /vault/tokens/:project`, `GET /vault/projects` | 🟢 In Progress |
+| Vault Engine      | `POST /vault/store`, `POST /vault/token`, `GET /vault/token/:project/:service`, `DELETE /vault/token/:project/:service`, `GET /vault/tokens/:project`, `DELETE /vault/tokens/:project`, `GET /vault/projects` | 🟢 In Progress |
 | Execution Engine  | `POST /execute` | 🟢 In Progress |
 | Gateway           | `POST /gateway/build-platform`, `POST /gateway/execute-action`, `POST /gateway/store-token`, `POST /gateway/run-blueprint` | 🟢 In Progress |
 

--- a/engines/vault/README.md
+++ b/engines/vault/README.md
@@ -11,6 +11,7 @@ It functions as a centralized "secret manager", allowing engines to **query for 
 The Vault Engine does not execute actions or orchestrate flows — it exists to **hold and serve sensitive authentication data** safely and efficiently.
 
 Tokens are persisted to a local `tokens.json` file on disk so that restarts do not lose stored credentials.
+The location of this file can be customized via the `VAULT_DATA_FILE` environment variable.
 
 ---
 
@@ -129,6 +130,11 @@ This endpoint is **implemented** in `src/index.ts` and deletes the token entry i
 GET /vault/tokens/:project
 ```
 Return all stored service tokens for the given project.
+
+```
+DELETE /vault/tokens/:project
+```
+Delete all stored tokens for the given project.
 
 ```
 GET /vault/projects

--- a/engines/vault/src/index.ts
+++ b/engines/vault/src/index.ts
@@ -1,5 +1,5 @@
 import express, { Request, Response } from "express";
-import { loadStore, saveStore, TokenStore } from "./storage";
+import { loadStore, saveStore, TokenStore, deleteProjectTokens } from "./storage";
 
 const app = express();
 app.use(express.json());
@@ -76,6 +76,18 @@ app.get('/vault/tokens/:project', (req: Request, res: Response) => {
     return res.status(404).json({ error: 'Project not found' });
   }
   return res.json({ tokens });
+});
+
+app.delete('/vault/tokens/:project', (req: Request, res: Response) => {
+  const { project } = req.params;
+  if (!project) {
+    return res.status(400).json({ error: 'project required' });
+  }
+  if (deleteProjectTokens(tokenStore, project)) {
+    saveStore(tokenStore);
+    return res.json({ success: true });
+  }
+  return res.status(404).json({ error: 'Project not found' });
 });
 
 app.get('/vault/projects', (_req: Request, res: Response) => {

--- a/engines/vault/src/storage.ts
+++ b/engines/vault/src/storage.ts
@@ -2,7 +2,9 @@ import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
 
-const DATA_FILE = path.join(__dirname, 'tokens.json');
+// Location for the token store file can be overridden for testing
+// or custom deployments via the VAULT_DATA_FILE environment variable.
+const DATA_FILE = process.env.VAULT_DATA_FILE || path.join(__dirname, 'tokens.json');
 
 const ALGORITHM = 'aes-256-ctr';
 const SECRET = (process.env.VAULT_SECRET || 'puraify_default_secret_key_32bytes!').slice(0, 32);
@@ -55,4 +57,16 @@ export function saveStore(store: TokenStore): void {
     }
   }
   fs.writeFileSync(DATA_FILE, JSON.stringify(toSave, null, 2));
+}
+
+/**
+ * Remove all tokens for the given project from the in-memory store.
+ * Returns true if the project existed and was removed.
+ */
+export function deleteProjectTokens(store: TokenStore, project: string): boolean {
+  if (store[project]) {
+    delete store[project];
+    return true;
+  }
+  return false;
 }

--- a/tests/vault/project-delete.test.js
+++ b/tests/vault/project-delete.test.js
@@ -1,0 +1,7 @@
+import assert from 'assert';
+import { deleteProjectTokens } from '../../engines/vault/src/storage.js';
+
+const store = { myproj: { slack: 'abc', notion: 'def' } };
+assert.strictEqual(deleteProjectTokens(store, 'myproj'), true);
+assert.deepStrictEqual(store, {});
+assert.strictEqual(deleteProjectTokens(store, 'missing'), false);


### PR DESCRIPTION
## Summary
- allow configuring Vault token file via `VAULT_DATA_FILE`
- add `DELETE /vault/tokens/:project` endpoint
- implement helper `deleteProjectTokens`
- document new endpoint and env var
- track route in `NAMESPACE_MAP.md` and update `SYSTEM_STATE.md`
- add unit test for project deletion

## Testing
- `npm test` *(fails: uvu not found)*

------
https://chatgpt.com/codex/tasks/task_e_68881b8ebec8832eb6503cda47a538e3