### PR TITLE
Fix Vault test imports and JS build

### DIFF
--- a/engines/vault/src/storage.js
+++ b/engines/vault/src/storage.js
@@ -1,0 +1,67 @@
+import fs from 'fs';
+import path, { dirname } from 'path';
+import crypto from 'crypto';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const DATA_FILE = process.env.VAULT_DATA_FILE || path.join(__dirname, 'tokens.json');
+
+const ALGORITHM = 'aes-256-ctr';
+const SECRET = (process.env.VAULT_SECRET || 'puraify_default_secret_key_32bytes!').slice(0, 32);
+
+function encrypt(text) {
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv(ALGORITHM, Buffer.from(SECRET), iv);
+  const encrypted = Buffer.concat([cipher.update(text), cipher.final()]);
+  return iv.toString('hex') + ':' + encrypted.toString('hex');
+}
+
+function decryptMaybe(data) {
+  try {
+    const [ivHex, encHex] = data.split(':');
+    if (!ivHex || !encHex) return data;
+    const iv = Buffer.from(ivHex, 'hex');
+    const encrypted = Buffer.from(encHex, 'hex');
+    const decipher = crypto.createDecipheriv(ALGORITHM, Buffer.from(SECRET), iv);
+    const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+    return decrypted.toString();
+  } catch {
+    return data;
+  }
+}
+
+export function loadStore() {
+  try {
+    const data = fs.readFileSync(DATA_FILE, 'utf-8');
+    const store = JSON.parse(data);
+    for (const project of Object.keys(store)) {
+      for (const service of Object.keys(store[project])) {
+        store[project][service] = decryptMaybe(store[project][service]);
+      }
+    }
+    return store;
+  } catch {
+    return {};
+  }
+}
+
+export function saveStore(store) {
+  const toSave = {};
+  for (const project of Object.keys(store)) {
+    toSave[project] = {};
+    for (const service of Object.keys(store[project])) {
+      toSave[project][service] = encrypt(store[project][service]);
+    }
+  }
+  fs.writeFileSync(DATA_FILE, JSON.stringify(toSave, null, 2));
+}
+
+export function deleteProjectTokens(store, project) {
+  if (store[project]) {
+    delete store[project];
+    return true;
+  }
+  return false;
+}

--- a/engines/vault/tests/project-delete.test.js
+++ b/engines/vault/tests/project-delete.test.js
@@ -1,6 +1,6 @@
 // Vault project delete test
 import assert from 'assert';
-import { deleteProjectTokens } from '../../engines/vault/src/storage.js';
+import { deleteProjectTokens } from '../src/storage.js';
 
 const store = { myproj: { slack: 'abc', notion: 'def' } };
 assert.strictEqual(deleteProjectTokens(store, 'myproj'), true);


### PR DESCRIPTION
## Summary
- fix path for deleteProjectTokens test
- add JS build of storage library for Node ESM

## Testing
- `node tests/sample.test.js && node tests/project-delete.test.js`
- `node tests/sample.test.js` (execution)
- `node tests/sample.test.js` (platform-builder)
- `node tests/sample.test.js` (gateway)


------
https://chatgpt.com/codex/tasks/task_e_6888f1d7930c832e8e5a55b53b79c227