### PR TITLE
Update engine spec guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ puraify/
 │   │   ├── src/
 │   │   │   └── index.ts            ← Entry point for Vault Engine
 │   │   ├── README.md               ← Vault Engine specification
-│   │   ├── ENGINE_SPEC.md          ← Manual spec placeholder
+│   │   ├── ENGINE_SPEC.md          ← Engine specification (must stay updated)
 │   │   ├── codex-todo.md           ← Local tasks
 │   │   └── tests/                  ← Vault tests
 │   ├── platform-builder/
@@ -55,7 +55,7 @@ puraify/
 │   │   ├── src/
 │   │   │   └── index.ts            ← Entry point for Platform Builder
 │   │   ├── README.md               ← Platform Builder specification
-│   │   ├── ENGINE_SPEC.md          ← Manual spec placeholder
+│   │   ├── ENGINE_SPEC.md          ← Engine specification (must stay updated)
 │   │   ├── codex-todo.md           ← Local tasks
 │   │   └── tests/                  ← Platform Builder tests
 │   ├── execution/
@@ -64,7 +64,7 @@ puraify/
 │   │   ├── src/
 │   │   │   └── index.ts            ← Entry point for Execution Engine
 │   │   ├── README.md               ← Execution Engine specification
-│   │   ├── ENGINE_SPEC.md          ← Manual spec placeholder
+│   │   ├── ENGINE_SPEC.md          ← Engine specification (must stay updated)
 │   │   ├── codex-todo.md           ← Local tasks
 │   │   └── tests/                  ← Execution Engine tests
 ├── gateway/
@@ -74,7 +74,7 @@ puraify/
 │   ├── src/
 │   │   └── index.ts                ← Main API router for the PURAIFY system
 │   ├── README.md                   ← Gateway specification
-│   ├── ENGINE_SPEC.md              ← Manual spec placeholder
+│   ├── ENGINE_SPEC.md              ← Engine specification (must stay updated)
 │   └── codex-todo.md               ← Local tasks
 ├── docker-compose.yml              ← Docker Compose configuration
 ├── ENGINE_DEPENDENCIES.md          ← Declared engine relationships

--- a/docs/CONTRIBUTION_PROTOCOL.md
+++ b/docs/CONTRIBUTION_PROTOCOL.md
@@ -210,16 +210,75 @@ This ensures unresolved items are visible, tagged, and tracked across sessions.
 
 ---
 
-📘 Engine Specification Awareness  
-Each engine folder may include an ENGINE_SPEC.md file describing its responsibilities, endpoints, integrations, and behavior.
+## 📘 ENGINE_SPEC.md — Engine Specification
 
-If Codex runs out of todos or Codex Notes, it should:
+Every engine folder **must** contain an `ENGINE_SPEC.md` file. This document is
+the single source of truth describing how the engine is expected to behave.
 
-- Check whether ENGINE_SPEC.md exists  
-- Review it for hints, expectations, or discrepancies  
-- Log potential tasks or missing capabilities based on it  
+The specification serves as the primary reference for **all** contributors and
+automated agents. It must clearly outline:
 
-If ENGINE_SPEC.md is missing or incomplete, Codex may log a todo or a note requesting clarification or manual input.
+1. **Engine goals and scope** – what the engine is responsible for and what it
+   does *not* handle.
+2. **API interfaces** – all endpoints with input/output schemas and examples.
+3. **Dependencies and integrations** – links to other engines or external
+   services.
+4. **File structure/system map** – high level overview of important files and
+   modules.
+
+### Mandatory Maintenance
+
+Whenever code in an engine changes, the corresponding `ENGINE_SPEC.md` **must be
+updated** to remain accurate. Updates must cover:
+
+- Adjusted goals or responsibilities.
+- Added, changed or removed endpoints with examples.
+- New usage scenarios or input/output expectations.
+- Modified dependencies or integration details.
+
+Code changes without a matching spec update are considered out of compliance and
+should be rejected in review.
+
+### Required Usage
+
+Before starting any task, contributors and Codex/GPT agents **must read the
+current engine spec**. If discrepancies or missing details are found, add a note
+in `codex-todo.md` (or inline Codex Note) and document it in
+`SYSTEM_STATE.md` under the Codex Notes Map.
+
+### Format and Style
+
+Engine specs must use Markdown with these sections at minimum:
+
+1. **Introduction and Engine Goals**
+2. **File Structure and System Map**
+3. **API Endpoints and Communication Protocols**
+4. **Input/Output Examples**
+5. **Integrations and Dependencies**
+
+Make them readable and accessible so developers and automated agents can quickly
+understand the engine’s contract.
+
+### Spec Change Workflow
+
+All changes to an `ENGINE_SPEC.md` require a logged proposal. Add the proposal
+under `## Proposed Actions` in the relevant `codex-todo.md` and mirror it in
+`PROPOSED_ACTIONS_LOG.md` with a unique ID, date, description, and status. A
+human approver must explicitly mark it as **Approved** before Codex updates the
+spec. After execution, update the log entry to **Executed** with the approver’s
+name and date.
+
+### Testing Against the Spec
+
+Unit or integration tests must verify that implemented endpoints and behaviour
+match what is defined in the spec. Any mismatch should fail tests and block the
+merge until resolved.
+
+### Codex Integration
+
+Codex must always read the engine spec before performing engine related tasks.
+If a spec change is required, Codex proposes it through the process above and
+waits for approval before modifying the file.
 
 ---
 

--- a/docs/PROPOSED_ACTIONS_LOG.md
+++ b/docs/PROPOSED_ACTIONS_LOG.md
@@ -2,6 +2,19 @@
 
 This file records environment and configuration changes proposed by Codex. Each entry tracks its status from proposal to execution.
 
+## Example Format
+
+| ID  | Date       | Description                     | Status    | Approver | Notes             |
+|-----|------------|---------------------------------|-----------|----------|-------------------|
+| PA5 | 2025-08-01 | Enable Redis cache for Vault    | Proposed  | CTO      | Awaiting approval |
+
+## Management Flow
+
+1. Add the proposal under `## Proposed Actions` in the matching `codex-todo.md`.
+2. Mirror the entry here with **Status: Proposed**.
+3. A human reviewer updates the status to **Approved** when accepted.
+4. After implementation, change the status to **Executed** and note the approver and date.
+
 | ID  | Date       | Description                            | Status   | Approver | Notes                   |
 |-----|------------|------------------------------------|----------|----------|-------------------------|
 | PA1 | 2025-07-28 | Create codex-todo format guide across engines | Executed | CEO      | Executed on 2025-07-28  |

--- a/engines/execution/ENGINE_SPEC.md
+++ b/engines/execution/ENGINE_SPEC.md
@@ -14,6 +14,18 @@ Common actions include:
 - Posting to Slack
 - Triggering webhooks
 
+## 📁 File Structure
+
+```text
+execution/
+├── package.json
+├── tsconfig.json
+├── src/
+│   └── index.ts
+├── README.md
+└── ENGINE_SPEC.md
+```
+
 ---
 
 ## ⚙️ Core Responsibilities

--- a/engines/execution/README.md
+++ b/engines/execution/README.md
@@ -41,7 +41,7 @@ npm test
 - `package.json` manages dependencies and scripts.
 - `tsconfig.json` contains TypeScript compiler settings.
 - `README.md` (this file) outlines Execution's responsibilities.
-- `ENGINE_SPEC.md` will hold the detailed manual spec for this engine.
+- `ENGINE_SPEC.md` contains the canonical specification for this engine and must remain in sync with the implemented code.
 
 ---
 

--- a/engines/platform-builder/README.md
+++ b/engines/platform-builder/README.md
@@ -42,7 +42,7 @@ npm test
 - `package.json` defines dependencies and scripts.
 - `tsconfig.json` contains TypeScript compiler settings.
 - `README.md` (this file) describes the engine's purpose and API.
-- `ENGINE_SPEC.md` is reserved for a detailed manual specification.
+- `ENGINE_SPEC.md` contains the canonical specification for this engine and must remain in sync with the implemented code.
 
 ---
 

--- a/engines/vault/README.md
+++ b/engines/vault/README.md
@@ -44,7 +44,7 @@ npm test
 - `src/storage.ts` loads and saves tokens to `tokens.json`.
 - `package.json` lists dependencies and scripts (currently minimal).
 - `README.md` (this file) documents Vault usage and API.
-- `ENGINE_SPEC.md` is reserved for a detailed manual specification.
+- `ENGINE_SPEC.md` contains the canonical specification for this engine and must remain in sync with the implemented code.
 
 ---
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -46,7 +46,7 @@ npm test
 - `package.json` defines Gateway dependencies and scripts.
 - `tsconfig.json` contains TypeScript compiler settings.
 - `README.md` (this file) explains routing behavior and planned endpoints.
-- `ENGINE_SPEC.md` will contain a detailed manual specification.
+- `ENGINE_SPEC.md` contains the canonical specification for this engine and must remain in sync with the implemented code.
 - `README.md` (this file) explains routing behavior and planned endpoints.
 
 ---


### PR DESCRIPTION
## Summary
- document strict ENGINE_SPEC.md maintenance
- clarify spec change workflow and format
- add example table & flow in Proposed Actions Log
- point README tree to engine specs as mandatory
- note spec sync rules in each engine README
- add structure section in Execution ENGINE_SPEC

## Testing
- `npm test` *(fails: `uvu: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68892d5be0bc832eacc4f3f1f21b4af7