### PR TITLE
Scan repo and log test runner inconsistency

### DIFF
--- a/SYSTEM_STATE.md
+++ b/SYSTEM_STATE.md
@@ -61,7 +61,7 @@ As of now, most engines only contain scaffold code. The Vault Engine persists to
 - [x] Define actual blueprint structure for Platform Builder (initial interface implemented)
 - [x] Add internal dev/test setup (e.g., nodemon, tsconfig)
 - [x] Added `docker-compose.yml` to run all engines together
-- [x] Node built-in test runner configured across engines
+- [x] uvu test runner configured across engines
 
 ---
 ## 🔄 Next Integration Steps

--- a/docs/codex-questions.md
+++ b/docs/codex-questions.md
@@ -106,3 +106,8 @@ _Status: ✅ Resolved_
 Execution Engine is responsible for fetching tokens from the Vault during action execution. Gateway only orchestrates requests.
 _Status: ✅ Resolved_
 
+
+### [Q8] Test runner inconsistency
+**Context:**
+Docs mention Node built-in test runner but package.json uses uvu. Should we switch to Node built-in or update docs to prefer uvu?
+_Status: Open_

--- a/docs/codex-todo.md
+++ b/docs/codex-todo.md
@@ -22,6 +22,7 @@
 
 
 
+- [ ] Verify test runner configuration across repo. Docs say Node built-in tests but package.json uses uvu. Align documentation or scripts.
 ## Proposed Actions
 **Log proposed environment updates here.** Each entry should include:
 - Description and rationale


### PR DESCRIPTION
## Summary
- noted that system docs said Node built‑in test runner but repo uses `uvu`
- added TODO to investigate mismatched test runner
- logged open question about which runner to use
- fixed `SYSTEM_STATE.md` bullet to reference `uvu`

## Testing
- `npm test` in `engines/platform-builder` *(fails: `uvu` not found)*
- `npm test` in `engines/execution` *(fails: `uvu` not found)*
- `npm test` in `engines/vault` *(fails: `uvu` not found)*
- `npm test` in `gateway` *(fails: `uvu` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68896b0af7a8832eb0bf456b688d4ef7