### PR TITLE
Fix Windows test imports

### DIFF
--- a/engines/execution/run-tests.js
+++ b/engines/execution/run-tests.js
@@ -1,6 +1,6 @@
 import { readdirSync } from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -9,7 +9,7 @@ const dir = path.join(__dirname, 'tests');
 for (const file of readdirSync(dir)) {
   if (file.endsWith('.js')) {
     console.log(`Running ${file}`);
-    await import(path.join(dir, file));
+    await import(pathToFileURL(path.join(dir, file)).href);
   }
 }
 console.log('All tests passed');

--- a/engines/platform-builder/run-tests.js
+++ b/engines/platform-builder/run-tests.js
@@ -1,6 +1,6 @@
 import { readdirSync } from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -9,7 +9,7 @@ const dir = path.join(__dirname, 'tests');
 for (const file of readdirSync(dir)) {
   if (file.endsWith('.js')) {
     console.log(`Running ${file}`);
-    await import(path.join(dir, file));
+    await import(pathToFileURL(path.join(dir, file)).href);
   }
 }
 console.log('All tests passed');

--- a/engines/vault/run-tests.js
+++ b/engines/vault/run-tests.js
@@ -1,6 +1,6 @@
 import { readdirSync } from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -9,7 +9,7 @@ const dir = path.join(__dirname, 'tests');
 for (const file of readdirSync(dir)) {
   if (file.endsWith('.js')) {
     console.log(`Running ${file}`);
-    await import(path.join(dir, file));
+    await import(pathToFileURL(path.join(dir, file)).href);
   }
 }
 console.log('All tests passed');

--- a/gateway/run-tests.js
+++ b/gateway/run-tests.js
@@ -1,6 +1,6 @@
 import { readdirSync } from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -9,7 +9,7 @@ const dir = path.join(__dirname, 'tests');
 for (const file of readdirSync(dir)) {
   if (file.endsWith('.js')) {
     console.log(`Running ${file}`);
-    await import(path.join(dir, file));
+    await import(pathToFileURL(path.join(dir, file)).href);
   }
 }
 console.log('All tests passed');


### PR DESCRIPTION
## Summary
- handle Windows file paths for dynamic imports

## Testing
- `npm run test:vault`
- `npm run test:execution`
- `npm run test:platform-builder`
- `npm run test:gateway`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a556f5e30832e990966e70d52198e