### PR TITLE
Clarify token fetch responsibility

### DIFF
--- a/ENGINE_DEPENDENCIES.md
+++ b/ENGINE_DEPENDENCIES.md
@@ -11,7 +11,7 @@ Currently has no runtime dependencies on other engines.
 - external: Slack API via `send_slack` action
 
 ### gateway
-- depends on: vault (`/vault/token` & `/vault/token/:project/:service`)
+- depends on: vault (`/vault/token` for storing credentials)
 - depends on: platform-builder (`/builder/create`)
 - depends on: execution (`/execute`)
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ PURAIFY is composed of specialized engines, each with a single responsibility:
 | Gateway | Routes requests and orchestrates calls between engines | 🟢 In Progress |
 
 Each engine is an isolated microservice that communicates through internal APIs.
+Each engine fetches its own tokens from the Vault Engine when needed; the Gateway only orchestrates requests and stores new credentials.
 
 ---
 

--- a/SYSTEM_STATE.md
+++ b/SYSTEM_STATE.md
@@ -66,8 +66,8 @@ As of now, most engines only contain scaffold code. The Vault Engine persists to
 ---
 ## 🔄 Next Integration Steps
 
-- Execution Engine must fetch tokens from Vault via `GET /vault/token/:project/:service` when actions need credentials.
-- Gateway orchestrates flow; Execution handles token retrieval; Vault serves tokens; Platform Builder supplies the blueprint.
+- Each engine must fetch its own tokens from Vault as needed via endpoints like `GET /vault/token/:project/:service`.
+- Gateway only orchestrates flow and stores new credentials; it does not fetch tokens for other engines.
 
 
 ## 🧠 Codex Notes Map
@@ -82,7 +82,7 @@ engines/execution/src/actions.ts:
 gateway/src/index.ts:
   Note: ✅ Gateway routing implemented; run-blueprint now continues after failures
 integration-design:
-  Note: ❓ Should Gateway or Execution Engine fetch Vault tokens during action execution?
+  Note: ✅ Each engine fetches its own tokens from Vault during action execution; Gateway only routes calls and stores credentials.
 root-level:
   Note: ENGINE_DEPENDENCIES.md, NAMESPACE_MAP.md and codex-todo.md added for cross-engine tracking. Engine-level codex-todo format expected.
   and human-todo.md added for manual environment tasks

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -130,6 +130,7 @@ export interface ActionResult {
 ## 🚧 Development Notes
 
 - Gateway is intentionally “thin” – it does not do logic, only routing and orchestration.
+- Tokens are fetched directly from the Vault by each engine; Gateway only stores credentials and forwards requests.
 - Future versions will include:
   - JWT-based auth
   - Rate limiting / API keys


### PR DESCRIPTION
## Summary
- document that each engine fetches tokens from Vault directly
- clarify Gateway dependency on Vault is only for storing credentials
- update next integration steps and notes in `SYSTEM_STATE.md`
- add note in Gateway README about token fetching

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ab97c6e88832eb914fcf81279c513