### PR TITLE
Add codex notes file

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ puraify/
 ├── docs/SYSTEM_RULES.md                 ← High-level system policies
 ├── docs/codex-questions.md              ← Architecture question log
 ├── docs/codex-todo.md                   ← Global tasks
+├── docs/codex-notes.md              ← Codex internal notes and process log
 ├── docs/human-todo.md              ← Manual setup tasks
 ├── docs/CODEX_TODO_FORMAT.md            ← Standard todo file format
 ├── README.md                       ← You are here — main project overview

--- a/SYSTEM_STATE.md
+++ b/SYSTEM_STATE.md
@@ -70,23 +70,7 @@ As of now, most engines only contain scaffold code. The Vault Engine persists to
 - Gateway only orchestrates flow and stores new credentials; it does not fetch tokens for other engines.
 
 
-## 🧠 Codex Notes Map
-engines/vault/src/index.ts:
-  Note: ✅ GET, POST and DELETE endpoints implemented with encrypted token persistence to `tokens.json` when `VAULT_SECRET` is set. Added listing endpoints `/vault/tokens/:project` and `/vault/projects`.
-engines/platform-builder/src/index.ts:
-  Note: ✅ Basic server with validation; parser supports "and", "then", comma lists
-engines/execution/src/index.ts:
-  Note: ✅ send_slack now calls Slack API via fetch; token fetched from Vault and 404 when missing
-engines/execution/src/actions.ts:
-  Note: ✅ Action handlers split into separate module for isolation
-gateway/src/index.ts:
-  Note: ✅ Gateway routing implemented; run-blueprint now continues after failures
-integration-design:
-  Note: ✅ Each engine fetches its own tokens from Vault during action execution; Gateway only routes calls and stores credentials.
-root-level:
-  Note: ENGINE_DEPENDENCIES.md, NAMESPACE_MAP.md and codex-todo.md added for cross-engine tracking. Engine-level codex-todo format expected.
-  and human-todo.md added for manual environment tasks
-
+All Codex notes are now kept in `docs/codex-notes.md`.
 ---
 
 ## 🧭 Summary

--- a/docs/CONTRIBUTION_PROTOCOL.md
+++ b/docs/CONTRIBUTION_PROTOCOL.md
@@ -92,7 +92,8 @@ This map shows where information lives and how contributors should communicate.
 | [`PROPOSED_ACTIONS_LOG.md`](PROPOSED_ACTIONS_LOG.md) | History of environment/config changes | Mirror proposals from todo files and update after approval/execution. |
 | [`codex-questions.md`](codex-questions.md) | Log of open architectural questions | Add `[Qx]` entries when uncertain. Humans reply with `[Ax]`. |
 | [`human-todo.md`](human-todo.md) | Tasks requiring human intervention or missing context | Tag tasks with `🔧 Requires human` or `🌐 External constraint`. |
-| [`SYSTEM_STATE.md`](../SYSTEM_STATE.md) | Snapshot of engine progress and the **Codex Notes Map** | Update whenever features or notes change. |
+| [`SYSTEM_STATE.md`](../SYSTEM_STATE.md) | Snapshot of engine progress | Update whenever features change. |
+| [`codex-notes.md`](codex-notes.md) | Codex notes, questions, and process logs | Record internal observations. |
 | `ENGINE_SPEC.md` (per engine) | Canonical behaviour specification | Keep in sync with code; propose edits via todo + log. |
 | [`ENGINES_INDEX.md`](../ENGINES_INDEX.md) | Registry of all engines and their status | Consult before assuming an engine exists. Do **not** auto‑update. |
 | [`ENGINE_DEPENDENCIES.md`](../ENGINE_DEPENDENCIES.md) | Declares runtime dependencies between engines | Update when new cross‑engine calls are added or removed. |
@@ -107,15 +108,15 @@ This map shows where information lives and how contributors should communicate.
 
 ### Workflow Guidelines
 
-1. **Start of a session** – read `SYSTEM_STATE.md`, root `codex-todo.md`, `human-todo.md` and any engine todo files you plan to modify. Check `codex-questions.md` for unresolved items.
+1. **Start of a session** – read `SYSTEM_STATE.md`, `codex-notes.md`, root `codex-todo.md`, `human-todo.md` and any engine todo files you plan to modify. Check `codex-questions.md` for unresolved items.
 2. **During work** – document new tasks in the appropriate todo file. For environment or configuration changes, add a proposal under `## Proposed Actions` and mirror it in `PROPOSED_ACTIONS_LOG.md`.
 3. **When blocked or unsure** – create a `[Qx]` entry in `codex-questions.md` and record the blocking task in `human-todo.md` tagged with `🔧 Requires human` or `🌐 External constraint`.
-4. **After completing a task** – mark the checkbox in the todo file, update engine READMEs and specs, and adjust `SYSTEM_STATE.md` progress or notes.
+4. **After completing a task** – mark the checkbox in the todo file, update engine READMEs and specs, and adjust `SYSTEM_STATE.md` progress and log new notes in `codex-notes.md`.
 5. **End of session** – ensure all updates are committed and summarise outstanding todos so future sessions have context.
 
 ### System Memory Tools
 
-- `SYSTEM_STATE.md` keeps a real‑time view of engine status and houses the **Codex Notes Map** for tracking inline notes across files.
+- `SYSTEM_STATE.md` keeps a real-time view of engine status. `codex-notes.md` tracks all internal notes, questions, and logs.
 - Todo files act as persistent memory of pending tasks. Together with the notes map they allow Codex to resume work seamlessly.
 - `PROPOSED_ACTIONS_LOG.md` provides historical context for environment changes so configuration is never altered without approval.
 - Open questions in these files represent tasks waiting for human input.  Codex will pause that work until feedback arrives, ensuring sessions remain connected over time.
@@ -143,7 +144,8 @@ Codex may create inline comment blocks or todo entries when encountering ideas o
 - Inline notes start with `/** 🧠 Codex Note:` and are meant for future context.
 - Engine folders can hold their own `codex-todo.md` for local tasks.
 - When a note or todo is resolved, remove it and update the relevant docs.
-- Track all active notes in `SYSTEM_STATE.md` under **Codex Notes Map** so future sessions can locate them.
+- Record all active notes in `codex-notes.md` so future sessions can locate them.
+- Do not store notes in `SYSTEM_STATE.md`; keep them only in `codex-notes.md`.
 - If a task cannot be completed due to external limits, keep it open with the appropriate tag and document the blocker.
 
 ---

--- a/docs/codex-notes.md
+++ b/docs/codex-notes.md
@@ -1,0 +1,19 @@
+# Codex Notes
+This file stores ongoing Codex notes, questions, and internal process logs. Keep new entries chronological.
+
+## 🧠 Codex Notes Map
+engines/vault/src/index.ts:
+  Note: ✅ GET, POST and DELETE endpoints implemented with encrypted token persistence to `tokens.json` when `VAULT_SECRET` is set. Added listing endpoints `/vault/tokens/:project` and `/vault/projects`.
+engines/platform-builder/src/index.ts:
+  Note: ✅ Basic server with validation; parser supports "and", "then", comma lists
+engines/execution/src/index.ts:
+  Note: ✅ send_slack now calls Slack API via fetch; token fetched from Vault and 404 when missing
+engines/execution/src/actions.ts:
+  Note: ✅ Action handlers split into separate module for isolation
+gateway/src/index.ts:
+  Note: ✅ Gateway routing implemented; run-blueprint now continues after failures
+integration-design:
+  Note: ✅ Each engine fetches its own tokens from Vault during action execution; Gateway only routes calls and stores credentials.
+root-level:
+  Note: ENGINE_DEPENDENCIES.md, NAMESPACE_MAP.md and codex-todo.md added for cross-engine tracking. Engine-level codex-todo format expected.
+  and human-todo.md added for manual environment tasks


### PR DESCRIPTION
## Summary
- create `codex-notes.md` to store internal notes
- move notes map out of `SYSTEM_STATE.md`
- document new notes file in the contribution protocol
- reference new file in root README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688abc05436c832eaed03edb279da0e0