### PR TITLE
Clean up engine test todos

### DIFF
--- a/codex-todo.md
+++ b/codex-todo.md
@@ -13,13 +13,27 @@ Track all system-wide and per-engine tasks in one place
 
 ## 🧩 Platform Builder
 
+- [ ] Blueprint parsing tests 🌐 External constraint (assert library only, needs supertest)
+
 ## 🔐 Vault
+
+- [ ] Vault API integration tests 🌐 External constraint (supertest not available offline)
 
 ## 🏃 Execution
 
+- [ ] Test send_slack posts message using mock server 🌐 External constraint (fetch-mock not available offline)
+- [ ] Test create_sheet posts to Google API using mock server 🌐 External constraint (fetch-mock not available offline)
+
 ## 🧪 Validation
 
+- [ ] Validate blueprint schema via /validation/check 🌐 External constraint (supertest not available offline)
+
 ## 📜 Gateway
+
+- [ ] Integration test for full pipeline via Gateway 🔧 Requires dependencies
+  - Blocked: npm install cannot run (no internet)
+- [ ] Validate `/gateway/run-blueprint` continues after failed actions
+  - Blocked: supertest not available offline
 
 ## 📝 Knowledge Engine
 
@@ -27,6 +41,7 @@ Track all system-wide and per-engine tasks in one place
 
 ## 📊 Monitoring & Logs Engine
 - [ ] Stream logs to external service (e.g., Loki) in future
+- [ ] API integration tests for /monitoring/logs 🌐 External constraint (supertest not available)
 
 ## 🔁 Feedback Loop
 

--- a/engines/execution/tests/codex-test-todo.md
+++ b/engines/execution/tests/codex-test-todo.md
@@ -1,3 +1,0 @@
-## Planned Tests
-- [ ] Test send_slack posts message using mock server 🌐 External constraint (fetch-mock not available offline)
-- [ ] Test create_sheet posts to Google API using mock server 🌐 External constraint (fetch-mock not available offline)

--- a/engines/logs/tests/codex-test-todo.md
+++ b/engines/logs/tests/codex-test-todo.md
@@ -1,2 +1,0 @@
-## Planned Tests
-- [ ] API integration tests for /monitoring/logs 🌐 External constraint (supertest not available)

--- a/engines/platform-builder/tests/codex-test-todo.md
+++ b/engines/platform-builder/tests/codex-test-todo.md
@@ -1,2 +1,0 @@
-## Planned Tests
-- [ ] Blueprint parsing tests 🌐 External constraint (assert library only, needs supertest)

--- a/engines/validation/tests/codex-test-todo.md
+++ b/engines/validation/tests/codex-test-todo.md
@@ -1,2 +1,0 @@
-## Planned Tests
-- [ ] Validate blueprint schema via /validation/check 🌐 External constraint (supertest not available offline)

--- a/engines/vault/tests/codex-test-todo.md
+++ b/engines/vault/tests/codex-test-todo.md
@@ -1,2 +1,0 @@
-## Planned Tests
-- [ ] Vault API integration tests 🌐 External constraint (supertest not available offline)

--- a/gateway/tests/codex-test-todo.md
+++ b/gateway/tests/codex-test-todo.md
@@ -1,5 +1,0 @@
-## Planned Tests
-- [ ] Integration test for full pipeline via Gateway 🔧 Requires dependencies
-  - Blocked: npm install cannot run (no internet)
-- [ ] Validate `/gateway/run-blueprint` continues after failed actions
-  - Blocked: supertest not available offline


### PR DESCRIPTION
## Summary
- move all test todo notes into centralized codex-todo
- delete leftover codex-test-todo.md files in engine tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bfc3f6fac832ebf71264535e81346