### PR TITLE
feat(platform-builder): add local prompt runner

### DIFF
--- a/engines/platform-builder/README.md
+++ b/engines/platform-builder/README.md
@@ -48,6 +48,16 @@ Copy `../../.env.example` to `.env` to configure `BUILDER_PORT` and service URLs
 - `README.md` (this file) describes the engine's purpose and API.
 - `ENGINE_SPEC.md` contains the canonical specification for this engine and must remain in sync with the implemented code.
 
+## 🧪 Local Prompt Runner
+
+Test how the builder parses a prompt without running the server:
+
+```bash
+node run-prompt.ts "Build a task management system with a form, users, and Slack notifications"
+```
+
+This prints the detected platform type, referenced components, and the generated blueprint JSON.
+
 ---
 
 ## 🧩 Role within the PURAIFY System

--- a/engines/platform-builder/run-prompt.ts
+++ b/engines/platform-builder/run-prompt.ts
@@ -1,0 +1,29 @@
+import { parsePrompt, detectPlatformType } from './src/parser.js';
+import type { BlueprintAction } from './src/parser.js';
+
+const prompt = process.argv[2];
+
+if (!prompt) {
+  console.error('Usage: node run-prompt.ts "<prompt>"');
+  process.exit(1);
+}
+
+const platformType = detectPlatformType(prompt);
+const actions: BlueprintAction[] = parsePrompt(prompt);
+const components = Array.from(new Set(
+  actions
+    .filter(a => a.type === 'add_component')
+    .map(a => a.params?.component)
+    .filter((c): c is string => Boolean(c))
+));
+
+const blueprint = {
+  platformType,
+  trigger: { type: 'manual' },
+  actions
+};
+
+console.log(`🧠 Platform Type: ${platformType ?? 'unknown'}`);
+console.log(`🧩 Components: ${JSON.stringify(components)}`);
+console.log('📦 Blueprint:');
+console.log(JSON.stringify(blueprint, null, 2));


### PR DESCRIPTION
## Summary
- add `run-prompt.ts` CLI to inspect platform-type, components, and blueprint generation
- document how to run the prompt parser script locally

## Testing
- `npm --prefix engines/platform-builder test`

------
https://chatgpt.com/codex/tasks/task_e_688f8dfd7f68832e8e871128ad855038