### PR TITLE
feat: add Support Platform type and Email Alerts component

### DIFF
--- a/communication/codex-notes.md
+++ b/communication/codex-notes.md
@@ -36,3 +36,7 @@ engines/platform-builder/src/parser.ts:
   Note: ✅ Loads platform knowledge to map prompts to components and platform types
 engines/platform-builder/src/index.ts:
   Note: ✅ Blueprints now include optional platformType detected from prompts
+platform-knowledge/:
+  Note: 🆕 Added Support Platform type with aliases and Email Alerts component with alias mappings
+engines/platform-builder/src/parser.ts:
+  Note: 🆕 detectPlatformType now handles alias objects in platform-types.json

--- a/engines/platform-builder/src/parser.js
+++ b/engines/platform-builder/src/parser.js
@@ -25,7 +25,18 @@ function findCategory(component) {
 }
 export function detectPlatformType(prompt) {
   const lower = prompt.toLowerCase();
-  return platformTypes.find(t => lower.includes(t.toLowerCase()));
+  for (const type of platformTypes) {
+    if (typeof type === 'string') {
+      if (lower.includes(type.toLowerCase())) {
+        return type;
+      }
+    } else {
+      const names = [type.name, ...(type.aliases || [])];
+      if (names.some(n => lower.includes(n.toLowerCase()))) {
+        return type.name;
+      }
+    }
+  }
 }
 function toAction(phrase) {
   const slack = phrase.match(/slack.*#(\S+)\s+(.*)/i);

--- a/engines/platform-builder/src/parser.ts
+++ b/engines/platform-builder/src/parser.ts
@@ -18,7 +18,8 @@ function readJson(file: string, fallback: any) {
   }
 }
 
-export const platformTypes: string[] = readJson('platform-types.json', []);
+export type PlatformTypeEntry = string | { name: string; aliases: string[] };
+export const platformTypes: PlatformTypeEntry[] = readJson('platform-types.json', []);
 export const platformComponents: Record<string, string[]> = readJson('platform-components.json', {});
 export const componentAliases: Record<string, string> = readJson('component-aliases.json', {});
 export const platformArchetypes: Record<string, string[]> = readJson('platform-archetypes.json', {});
@@ -33,7 +34,18 @@ function findCategory(component: string): string | undefined {
 
 export function detectPlatformType(prompt: string): string | undefined {
   const lower = prompt.toLowerCase();
-  return platformTypes.find(t => lower.includes(t.toLowerCase()));
+  for (const type of platformTypes) {
+    if (typeof type === 'string') {
+      if (lower.includes(type.toLowerCase())) {
+        return type;
+      }
+    } else {
+      const names = [type.name, ...(type.aliases || [])];
+      if (names.some(n => lower.includes(n.toLowerCase()))) {
+        return type.name;
+      }
+    }
+  }
 }
 
 function toAction(phrase: string): BlueprintAction {

--- a/platform-knowledge/component-aliases.json
+++ b/platform-knowledge/component-aliases.json
@@ -5,5 +5,9 @@
   "upload doc": "File Uploads",
   "upload file": "File Uploads",
   "send message": "Chat Prompt Input",
-  "start chat": "Chat Prompt Input"
+  "start chat": "Chat Prompt Input",
+  "email alert": "Email Alerts",
+  "email alerts": "Email Alerts",
+  "email notification": "Email Alerts",
+  "notifications via email": "Email Alerts"
 }

--- a/platform-knowledge/platform-components.json
+++ b/platform-knowledge/platform-components.json
@@ -46,7 +46,8 @@
     "Generate File (PDF / Excel)",
     "Update Record",
     "Open Task / Ticket",
-    "Calendar Event"
+    "Calendar Event",
+    "Email Alerts"
   ],
   "UI / Visualization": [
     "Tables / Grids",

--- a/platform-knowledge/platform-types.json
+++ b/platform-knowledge/platform-types.json
@@ -12,4 +12,9 @@
   "SaaS App Builder",
   "Data Dashboard Platform",
   "Workflow Orchestration Tool"
+  ,
+  {
+    "name": "Support Platform",
+    "aliases": ["support platform", "ticketing system", "customer service platform"]
+  }
 ]


### PR DESCRIPTION
## Summary
- add Support Platform platform type with alias detection
- add Email Alerts output component and alias mappings
- extend parser to recognize platform type aliases

## Testing
- `npm test`
- `node --loader ts-node/esm run-prompt.ts "Build a support platform with users, tickets, and email alerts"`


------
https://chatgpt.com/codex/tasks/task_e_688f9071de70832ea08df566f3603528