### PR TITLE
feat: add GPT fallback to platform builder

### DIFF
--- a/communication/codex-notes.md
+++ b/communication/codex-notes.md
@@ -40,3 +40,5 @@ platform-knowledge/:
   Note: 🆕 Added Support Platform type with aliases and Email Alerts component with alias mappings
 engines/platform-builder/src/parser.ts:
   Note: 🆕 detectPlatformType now handles alias objects in platform-types.json
+engines/platform-builder/src/parser.ts:
+  Note: 🆕 Added GPT fallback to supplement platformType and components; unknown types logged to codex-notes

--- a/communication/codex-todo.md
+++ b/communication/codex-todo.md
@@ -20,6 +20,7 @@ Track all system-wide and per-engine tasks in one place
 ## 🧩 Platform Builder
 
 - [ ] Blueprint parsing tests 🌐 External constraint (assert library only, needs supertest)
+- [ ] Mock GPT fallback in parser tests
 
 ## 🔐 Vault
 

--- a/engines/platform-builder/src/gpt-helper.js
+++ b/engines/platform-builder/src/gpt-helper.js
@@ -1,0 +1,32 @@
+export async function askGPTForBlueprintHints(prompt) {
+  const mock = globalThis.__mockAskGPTForBlueprintHints;
+  if (typeof mock === 'function') {
+    return await mock(prompt);
+  }
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return { platformType: 'unknown', components: [] };
+  }
+  const systemInstruction = `You are helping build internal blueprints for a low-code system.\n\nFrom the user prompt, identify:\n- The most likely platformType (from known categories like CRM, Support Platform, Education Platform, etc.)\n- The components involved (using normalized terms: Users, Tickets, Login, Scheduler, Webhook, Email Alerts, etc.)\n\nReturn the result in this exact JSON format:\n\n{\n  "platformType": "string",\n  "components": [\n    { "component": "string", "category": "string" }\n  ]\n}\n\nUse clear internal naming. If unsure, make the best educated guess.`;
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [
+          { role: 'system', content: systemInstruction },
+          { role: 'user', content: prompt }
+        ]
+      })
+    });
+    const data = await res.json();
+    const text = data?.choices?.[0]?.message?.content || '{}';
+    return JSON.parse(text);
+  } catch {
+    return { platformType: 'unknown', components: [] };
+  }
+}

--- a/engines/platform-builder/src/gpt-helper.ts
+++ b/engines/platform-builder/src/gpt-helper.ts
@@ -1,0 +1,42 @@
+export interface GPTComponentHint {
+  component: string;
+  category?: string;
+}
+
+export interface GPTBlueprintHints {
+  platformType?: string;
+  components: GPTComponentHint[];
+}
+
+export async function askGPTForBlueprintHints(prompt: string): Promise<GPTBlueprintHints> {
+  const mock = (globalThis as any).__mockAskGPTForBlueprintHints;
+  if (typeof mock === 'function') {
+    return await mock(prompt);
+  }
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return { platformType: 'unknown', components: [] };
+  }
+  const systemInstruction = `You are helping build internal blueprints for a low-code system.\n\nFrom the user prompt, identify:\n- The most likely platformType (from known categories like CRM, Support Platform, Education Platform, etc.)\n- The components involved (using normalized terms: Users, Tickets, Login, Scheduler, Webhook, Email Alerts, etc.)\n\nReturn the result in this exact JSON format:\n\n{\n  "platformType": "string",\n  "components": [\n    { "component": "string", "category": "string" }\n  ]\n}\n\nUse clear internal naming. If unsure, make the best educated guess.`;
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [
+          { role: 'system', content: systemInstruction },
+          { role: 'user', content: prompt }
+        ]
+      })
+    });
+    const data = await res.json();
+    const text = data?.choices?.[0]?.message?.content || '{}';
+    return JSON.parse(text);
+  } catch {
+    return { platformType: 'unknown', components: [] };
+  }
+}

--- a/engines/platform-builder/src/index.js
+++ b/engines/platform-builder/src/index.js
@@ -1,5 +1,5 @@
 import express from "express";
-import { parsePrompt, detectPlatformType } from './parser.js';
+import { parsePrompt } from './parser.js';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -34,13 +34,12 @@ function loadEnv() {
 loadEnv();
 const app = express();
 app.use(express.json());
-app.post('/builder/create', (req, res) => {
+app.post('/builder/create', async (req, res) => {
   const { prompt, project } = req.body || {};
   if (typeof prompt !== 'string' || typeof project !== 'string') {
     return res.status(400).json({ error: 'prompt and project are required' });
   }
-  const actions = parsePrompt(prompt);
-  const platformType = detectPlatformType(prompt);
+  const { platformType, actions } = await parsePrompt(prompt);
   const blueprint = {
     project,
     blueprint: {

--- a/engines/platform-builder/src/index.ts
+++ b/engines/platform-builder/src/index.ts
@@ -1,6 +1,6 @@
 import express, { Request, Response } from "express";
 
-import { parsePrompt, BlueprintAction, detectPlatformType } from './parser.js';
+import { parsePrompt, BlueprintAction } from './parser.js';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -50,15 +50,12 @@ interface BlueprintResponse {
 const app = express();
 app.use(express.json());
 
-app.post('/builder/create', (req: Request, res: Response) => {
+app.post('/builder/create', async (req: Request, res: Response) => {
   const { prompt, project } = req.body || {};
   if (typeof prompt !== 'string' || typeof project !== 'string') {
     return res.status(400).json({ error: 'prompt and project are required' });
   }
-
-  const actions: BlueprintAction[] = parsePrompt(prompt);
-  const platformType = detectPlatformType(prompt);
-
+  const { platformType, actions } = await parsePrompt(prompt);
   const blueprint: BlueprintResponse = {
     project,
     blueprint: {

--- a/engines/platform-builder/src/parser.ts
+++ b/engines/platform-builder/src/parser.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { askGPTForBlueprintHints } from './gpt-helper.js';
 
 export interface BlueprintAction {
   type: string;
@@ -80,10 +81,54 @@ function toAction(phrase: string): BlueprintAction {
   return { type: 'log_message', params: { message: phrase } };
 }
 
-export function parsePrompt(prompt: string): BlueprintAction[] {
+function parseActions(prompt: string): BlueprintAction[] {
   const parts = String(prompt)
     .split(/\band\b|\bthen\b|,/i)
     .map(p => p.trim())
     .filter(Boolean);
   return parts.map(toAction);
+}
+
+function isKnownPlatformType(type: string): boolean {
+  return platformTypes.some(t => {
+    const name = typeof t === 'string' ? t : t.name;
+    return name.toLowerCase() === type.toLowerCase();
+  });
+}
+
+function logMissingPlatformType(type: string) {
+  if (process.env.SKIP_CODEX_NOTES === '1') return;
+  try {
+    const notesPath = path.resolve(__dirname, '../../../communication/codex-notes.md');
+    const note = `engines/platform-builder/src/parser.ts:\n  Note: Suggested platform type "${type}"\n`;
+    fs.appendFileSync(notesPath, note);
+  } catch {}
+}
+
+export async function parsePrompt(prompt: string): Promise<{ platformType: string; actions: BlueprintAction[] }> {
+  const actions = parseActions(prompt);
+  let platformType = detectPlatformType(prompt) || 'unknown';
+  const components = actions.filter(a => a.type === 'add_component');
+  if (platformType === 'unknown' || components.length === 0) {
+    const hints = await askGPTForBlueprintHints(prompt);
+    if (platformType === 'unknown' && hints.platformType && hints.platformType !== 'unknown') {
+      platformType = hints.platformType;
+      if (!isKnownPlatformType(platformType)) {
+        logMissingPlatformType(platformType);
+      }
+    }
+    for (const hint of hints.components || []) {
+      const exists = components.some(c => c.params?.component.toLowerCase() === hint.component.toLowerCase());
+      if (!exists) {
+        const category = hint.category || findCategory(hint.component);
+        const action: BlueprintAction = {
+          type: 'add_component',
+          params: { component: hint.component, category }
+        };
+        actions.push(action);
+        components.push(action);
+      }
+    }
+  }
+  return { platformType, actions };
 }

--- a/engines/platform-builder/tests/parser.test.js
+++ b/engines/platform-builder/tests/parser.test.js
@@ -1,8 +1,9 @@
 import assert from 'assert';
 import { parsePrompt } from '../src/parser.js';
 
-const result = parsePrompt('send slack #general hello then http get http://ex.com');
-assert.deepStrictEqual(result, [
+process.env.SKIP_CODEX_NOTES = '1';
+const result = await parsePrompt('send slack #general hello then http get http://ex.com');
+assert.deepStrictEqual(result.actions, [
   { type: 'send_slack', params: { channel: '#general', message: 'hello' } },
   { type: 'http_request', params: { method: 'GET', url: 'http://ex.com' } }
 ]);

--- a/engines/platform-builder/tests/sample.test.js
+++ b/engines/platform-builder/tests/sample.test.js
@@ -2,9 +2,27 @@
 import assert from 'assert';
 import { parsePrompt, detectPlatformType } from '../src/parser.js';
 
+process.env.SKIP_CODEX_NOTES = '1';
+
 // detect platform type
 assert.strictEqual(detectPlatformType('Build a CRM platform'), 'CRM Platform');
 
 // parse component action via alias
-const actions = parsePrompt('please make a form');
-assert.deepStrictEqual(actions[0], { type: 'add_component', params: { component: 'Forms', category: 'Input' } });
+const parsed = await parsePrompt('please make a form');
+assert.deepStrictEqual(parsed.actions[0], { type: 'add_component', params: { component: 'Forms', category: 'Input' } });
+
+// GPT fallback for fuzzy prompt (mocked)
+process.env.SKIP_CODEX_NOTES = '1';
+globalThis.__mockAskGPTForBlueprintHints = async () => ({
+  platformType: 'Support Platform',
+  components: [
+    { component: 'Signups', category: 'Users' },
+    { component: 'Calendar Slots', category: 'Scheduler' },
+    { component: 'Email Confirmations', category: 'Notifications' }
+  ]
+});
+const fuzzy = await parsePrompt('Build a volunteer matching app with signups, calendar slots, and email confirmations');
+assert.strictEqual(fuzzy.platformType, 'Support Platform');
+assert.ok(fuzzy.actions.some(a => a.params?.component === 'Signups'));
+assert.ok(fuzzy.actions.some(a => a.params?.component === 'Calendar Slots'));
+assert.ok(fuzzy.actions.some(a => a.params?.component === 'Email Confirmations'));


### PR DESCRIPTION
## Summary
- augment platform builder parser with GPT-based fallback when platform type or components cannot be resolved
- add gpt-helper module for querying GPT or mocked responses
- document GPT fallback in codex notes and add todo for parser tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f9a896858832e94666e9ecc62dbad