### PR TITLE
refactor: use async parser in prompt runner

### DIFF
--- a/engines/platform-builder/run-prompt.ts
+++ b/engines/platform-builder/run-prompt.ts
@@ -1,5 +1,4 @@
-import { parsePrompt, detectPlatformType } from './src/parser.js';
-import type { BlueprintAction } from './src/parser.js';
+import { parsePrompt } from './src/parser.js';
 
 const prompt = process.argv.slice(2).join(' ');
 
@@ -12,8 +11,7 @@ console.log("📦 Prompt received:", prompt);
 
 (async () => {
   try {
-    const platformType = await detectPlatformType(prompt);
-    const actions: BlueprintAction[] = await parsePrompt(prompt);
+    const { platformType, actions } = await parsePrompt(prompt);
 
     const components = Array.from(new Set(
       actions


### PR DESCRIPTION
## Summary
- update prompt runner to use async `parsePrompt` API, enabling GPT-powered fallback

## Testing
- `npm test`
- `TS_NODE_COMPILER_OPTIONS='{"module":"ESNext"}' node --loader ts-node/esm run-prompt.ts "Build a task management system with a form, users, and Slack notifications"`


------
https://chatgpt.com/codex/tasks/task_e_688fa770f7d0832e8da8b13c3e00782d