### PR TITLE
Improve GPT fallback logging and parsing

### DIFF
--- a/engines/platform-builder/src/gpt-helper.js
+++ b/engines/platform-builder/src/gpt-helper.js
@@ -7,7 +7,7 @@ export async function askGPTForBlueprintHints(prompt) {
   if (!apiKey) {
     return { platformType: 'unknown', components: [] };
   }
-  const systemInstruction = `You are helping build internal blueprints for a low-code system.\n\nFrom the user prompt, identify:\n- The most likely platformType (from known categories like CRM, Support Platform, Education Platform, etc.)\n- The components involved (using normalized terms: Users, Tickets, Login, Scheduler, Webhook, Email Alerts, etc.)\n\nReturn the result in this exact JSON format:\n\n{\n  "platformType": "string",\n  "components": [\n    { "component": "string", "category": "string" }\n  ]\n}\n\nUse clear internal naming. If unsure, make the best educated guess.`;
+  const systemInstruction = `You are helping build internal blueprints for a low-code system.\n\nFrom the user prompt, identify:\n- The most likely platformType (from known categories like CRM, Support Platform, Education Platform, etc.)\n- The components involved (using normalized terms: Users, Tickets, Login, Scheduler, Webhook, Email Alerts, etc.)\n\nReturn ONLY a JSON object in this exact format:\n\n{\n  "platformType": "string",\n  "components": [\n    { "component": "string", "category": "string" }\n  ]\n}\n\nUse clear internal naming. If unsure, make the best educated guess.`;
   try {
     const res = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
@@ -16,7 +16,7 @@ export async function askGPTForBlueprintHints(prompt) {
         Authorization: `Bearer ${apiKey}`
       },
       body: JSON.stringify({
-        model: 'gpt-4o-mini',
+        model: 'gpt-4o',
         messages: [
           { role: 'system', content: systemInstruction },
           { role: 'user', content: prompt }
@@ -25,8 +25,14 @@ export async function askGPTForBlueprintHints(prompt) {
     });
     const data = await res.json();
     const text = data?.choices?.[0]?.message?.content || '{}';
-    return JSON.parse(text);
-  } catch {
+    try {
+      return JSON.parse(text);
+    } catch (err) {
+      console.error('Failed to parse GPT hints:', text, err);
+      return { platformType: 'unknown', components: [] };
+    }
+  } catch (err) {
+    console.error('askGPTForBlueprintHints error:', err);
     return { platformType: 'unknown', components: [] };
   }
 }

--- a/engines/platform-builder/src/gpt-helper.ts
+++ b/engines/platform-builder/src/gpt-helper.ts
@@ -28,7 +28,7 @@ From the user prompt, identify:
 - The most likely platformType (from known categories like CRM, Support Platform, Education Platform, etc.)
 - The components involved (using normalized terms: Users, Tickets, Login, Scheduler, Webhook, Email Alerts, etc.)
 
-Return the result in this exact JSON format:
+Return ONLY a JSON object in this exact format:
 
 {
   "platformType": "string",
@@ -47,7 +47,7 @@ Use clear internal naming. If unsure, make the best educated guess.`;
         Authorization: `Bearer ${apiKey}`
       },
       body: JSON.stringify({
-        model: 'gpt-4o-mini',
+        model: 'gpt-4o',
         messages: [
           { role: 'system', content: systemInstruction },
           { role: 'user', content: prompt }
@@ -57,9 +57,14 @@ Use clear internal naming. If unsure, make the best educated guess.`;
 
     const data = await res.json();
     const text = data?.choices?.[0]?.message?.content || '{}';
-    return JSON.parse(text);
-
-  } catch {
+    try {
+      return JSON.parse(text);
+    } catch (err) {
+      console.error('Failed to parse GPT hints:', text, err);
+      return { platformType: 'unknown', components: [] };
+    }
+  } catch (err) {
+    console.error('askGPTForBlueprintHints error:', err);
     return { platformType: 'unknown', components: [] };
   }
 }

--- a/engines/platform-builder/src/parser.js
+++ b/engines/platform-builder/src/parser.js
@@ -91,6 +91,7 @@ export async function parsePrompt(prompt) {
   const components = actions.filter(a => a.type === 'add_component');
   if (platformType === 'unknown' || components.length === 0) {
     const hints = await askGPTForBlueprintHints(prompt);
+    console.log('📨 GPT Hints:', hints);
     if (platformType === 'unknown' && hints.platformType && hints.platformType !== 'unknown') {
       platformType = hints.platformType;
       if (!isKnownPlatformType(platformType)) {

--- a/engines/platform-builder/src/parser.ts
+++ b/engines/platform-builder/src/parser.ts
@@ -111,6 +111,7 @@ export async function parsePrompt(prompt: string): Promise<{ platformType: strin
   const components = actions.filter(a => a.type === 'add_component');
   if (platformType === 'unknown' || components.length === 0) {
     const hints = await askGPTForBlueprintHints(prompt);
+    console.log('📨 GPT Hints:', hints);
     if (platformType === 'unknown' && hints.platformType && hints.platformType !== 'unknown') {
       platformType = hints.platformType;
       if (!isKnownPlatformType(platformType)) {

--- a/engines/platform-builder/tests/sample.test.js
+++ b/engines/platform-builder/tests/sample.test.js
@@ -26,3 +26,18 @@ assert.strictEqual(fuzzy.platformType, 'Support Platform');
 assert.ok(fuzzy.actions.some(a => a.params?.component === 'Signups'));
 assert.ok(fuzzy.actions.some(a => a.params?.component === 'Calendar Slots'));
 assert.ok(fuzzy.actions.some(a => a.params?.component === 'Email Confirmations'));
+
+// GPT fallback example for task management prompt
+globalThis.__mockAskGPTForBlueprintHints = async () => ({
+  platformType: 'Task Management',
+  components: [
+    { component: 'Form', category: 'Input' },
+    { component: 'Users', category: 'Entities' },
+    { component: 'Slack', category: 'Output' }
+  ]
+});
+const task = await parsePrompt('Build a task management system with a form, users, and Slack notifications');
+assert.strictEqual(task.platformType, 'Task Management');
+assert.ok(task.actions.some(a => a.params?.component === 'Form'));
+assert.ok(task.actions.some(a => a.params?.component === 'Users'));
+assert.ok(task.actions.some(a => a.params?.component === 'Slack'));


### PR DESCRIPTION
## Summary
- log GPT blueprint hints during fallback
- use `gpt-4o` with stricter JSON instructions and error handling
- test task management prompt to ensure hints merge correctly

## Testing
- `npm --prefix engines/platform-builder test`

------
https://chatgpt.com/codex/tasks/task_e_688fae08e510832e9c967781015fdd5e