### PR TITLE
feat: load env automatically

### DIFF
--- a/engines/platform-builder/src/gpt-helper.ts
+++ b/engines/platform-builder/src/gpt-helper.ts
@@ -1,5 +1,5 @@
-import dotenv from 'dotenv';
-dotenv.config({ path: '../../.env' }); // טוען את מפתח ה-API
+import 'dotenv/config';
+console.log('🔑 Loaded API key:', process.env.OPENAI_API_KEY?.slice(0, 10) + '...');
 
 export interface GPTComponentHint {
   component: string;


### PR DESCRIPTION
## Summary
- load `.env` automatically for platform-builder
- log loaded OpenAI API key prefix for debugging

## Testing
- `npm run test:platform-builder`

------
https://chatgpt.com/codex/tasks/task_e_688fb0d38798832e9d2fd385a55e78d7