### PR TITLE
chore(platform-builder): add env example

### DIFF
--- a/engines/platform-builder/.env.example
+++ b/engines/platform-builder/.env.example
@@ -1,0 +1,10 @@
+# Example environment for Platform Builder engine
+# Copy to .env and adjust values as needed
+
+# API key used for GPT calls
+OPENAI_API_KEY=changeme
+
+# Optional service overrides
+LOGS_URL=http://localhost:4005
+BUILDER_PORT=4001
+SKIP_CODEX_NOTES=0


### PR DESCRIPTION
## Summary
- add `.env.example` for Platform Builder engine with `OPENAI_API_KEY` and service overrides for local testing

## Testing
- `npm test` (from `engines/platform-builder`)


------
https://chatgpt.com/codex/tasks/task_e_688fb601cddc832ea0b4fa6724c14311