### PR TITLE
fix: run gateway in CommonJS mode

### DIFF
--- a/gateway/package.json
+++ b/gateway/package.json
@@ -19,6 +19,5 @@
     "@types/express": "^5.0.3",
     "fetch-mock": "^12.5.3",
     "supertest": "^7.1.4"
-  },
-  "type": "module"
+  }
 }


### PR DESCRIPTION
## Summary
- run Gateway with `ts-node` so CommonJS `exports` work without ESM loader

## Testing
- `npm run dev`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fbfdb8230832ebcaa1e0513af23c6